### PR TITLE
Webform logic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .idea/webform_strawberry.iml
 
 .idea/vcs.xml
+
+src/Tools/Iiif/IiifHelper.php

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
@@ -190,7 +190,7 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
             // Happens that this is my demo default
             // @todo this for a configurable setting
             // @todo create a webform  on the fly if all fails?
-            // @todo we need to ship this default webform with the module
+            // @todo we need to ship this default webform with the module named 'webform_strawberry_default
             $my_webform_machinename = 'webform_strawberry_default';
 
         }

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -30,7 +30,7 @@ class WebformLoC extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public function getPluginLabel() {
-     $this->t('LoC Subject Headings Autocomplete');
+    return $this->elementManager->isExcluded('webform_metadata_loc') ? $this->t('Subject Headings') : parent::getPluginLabel();
   }
 
   /**

--- a/src/Plugin/WebformElement/WebformWikiData.php
+++ b/src/Plugin/WebformElement/WebformWikiData.php
@@ -30,7 +30,7 @@ class WebformWikiData extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public function getPluginLabel() {
-     $this->t('Wikidata Items Autocomplete');
+    return $this->elementManager->isExcluded('webform_metadata_wikidata') ? $this->t('WIKIDATA Subject Headings') : parent::getPluginLabel();
   }
 
   /**

--- a/src/Plugin/WebformHandler/strawberryFieldharvester.php
+++ b/src/Plugin/WebformHandler/strawberryFieldharvester.php
@@ -385,8 +385,8 @@ class strawberryFieldharvester extends WebformHandlerBase
               'type' => 'Image',
               'url' =>  $uri,
               'checksum' => $md5,
-              'for' =>  $key,
-              'fid' => (int) $file->id(),
+              'dr:for' =>  $key,
+              'dr:fid' => (int) $file->id(),
               'name' => $file->getFilename()
             ];
             $relativefolder = substr($md5,0,3);
@@ -407,7 +407,7 @@ class strawberryFieldharvester extends WebformHandlerBase
             $fileinfo_many[$destination_uri] = $fileinfo;
 
         }
-        $cleanvalues['Media'] = $fileinfo_many;
+        $cleanvalues['as:image'] = $fileinfo_many;
 
     }
 

--- a/src/Plugin/WebformHandler/strawberryFieldharvester.php
+++ b/src/Plugin/WebformHandler/strawberryFieldharvester.php
@@ -383,7 +383,8 @@ class strawberryFieldharvester extends WebformHandlerBase
 
             $fileinfo=[
               'type' => 'Image',
-              'url' =>  $uri,
+              'dr:url' =>  $uri,
+              'url' => $uri,
               'checksum' => $md5,
               'dr:for' =>  $key,
               'dr:fid' => (int) $file->id(),

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -198,7 +198,7 @@ function webform_strawberryfield_node_presave(ContentEntityInterface $entity) {
   // Get the default image settings, return if not saving an image field storage
   // or image field entity.
   //@TODO refactor this into OcfHelper. That class will deal with Media and Storage
-  // @TODO even better, refactor this as part of the AS/event driven architecture
+  //@TODO even better, refactor this as part of the AS/event driven architecture
   // And make all this efforts JSON based plugins.
   foreach ($field_item_lists as $field)
     $type = $field->getFieldDefinition()->getType();
@@ -206,14 +206,14 @@ function webform_strawberryfield_node_presave(ContentEntityInterface $entity) {
     if (!$field->isEmpty) {
       foreach($field->getValue() as $delta => $fieldvalue) {
         $arrayMedia = json_decode($fieldvalue['value'], true);
-        if (isset($arrayMedia['Media'])){
-          foreach ($arrayMedia['Media'] as $id => &$info) {
-            if (isset($info['url'])) {
-              if (($id != $info['url']) && isset($info['fid']) && is_numeric($info['fid'])) {
+        if (isset($arrayMedia['as:image'])){
+          foreach ($arrayMedia['as:image'] as $id => &$info) {
+            if (isset($info['dr:url'])) {
+              if (($id != $info['dr:url']) && isset($info['dr:fid']) && is_numeric($info['dr:fid'])) {
                 $destination_folder = \Drupal::service('file_system')->dirname($id);
                 file_prepare_directory($destination_folder, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
-                $destination_uri = file_unmanaged_move($info['url'], $id );
-                $file = File::load($info['fid']);
+                $destination_uri = file_unmanaged_move($info['dr:url'], $id );
+                $file = File::load($info['dr:fid']);
                 $file->setFileUri($destination_uri);
                 //@TODO we want probaly here to maintain the original file that was uploaded.
                 $file->setFileName(\Drupal::service('file_system')->basename($destination_uri));
@@ -226,7 +226,7 @@ function webform_strawberryfield_node_presave(ContentEntityInterface $entity) {
                     $entity->id()
                   );
                 }
-                $info['url'] = $id;
+                $info['dr:url'] = $id;
               }
             }
           }


### PR DESCRIPTION
- Better normalization of image container for JSON keys: now using activity stream `as:image`
- Prefix Drupal internalities (like fid, etc) to `dr:`
- Fix missing labels for Authority Record Webform Field autocompletes

Funny: LoC and WikiData endpoint access from AWS wows.
`@TODO:`Make sure we publish a valid `@context` that includes ActivityStream and dr: so not PHP, code, reading apps, if we ever expose our raw internalities, know what is what.