### PR TITLE
Inline webform work

### DIFF
--- a/js/hidenodesubmit-webform_strawberryfield.js
+++ b/js/hidenodesubmit-webform_strawberryfield.js
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Expands the behaviour of the default autocompletion to fill 2 fields.
+ */
+
+(function ($, Drupal, drupalSettings) {
+
+    'use strict';
+
+    /**
+     * Attaches our custom show/hide node submit button
+     *
+     * @type {Drupal~behavior}
+     *
+     * @prop {Drupal~behaviorAttach} attach
+     *   Attaches the autocomplete behaviors.
+     */
+    Drupal.behaviors.webformstrawberryHideNodeActions = {
+        attach: function (context, settings) {
+            // Find all our fields with autocomplete settings
+
+            if ($('.webform-confirmation',context).length) {
+                $('input[data-drupal-selector="edit-submit"]').show();
+            }
+
+
+        }
+    };
+})(jQuery, Drupal, drupalSettings);

--- a/webform_strawberryfield.libraries.yml
+++ b/webform_strawberryfield.libraries.yml
@@ -3,3 +3,11 @@ webform_strawberryfield.metadataauth.autocomplete:
     js/metadataauth-webform_strawberryfield.js: {}
   dependencies:
     - core/drupal.autocomplete
+webform_strawberryfield.nodeactions.toggle:
+  js:
+    js/hidenodesubmit-webform_strawberryfield.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+    - core/drupal.form

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -86,7 +86,7 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
         if ($element['#type'] == 'webform_wizard_page') {
           $form['actions']['edit_wizard_page_'.$key][] = [
             '#type' => 'submit',
-            '#value' => 'edit '.$key,
+            '#value' => 'edit '.$element['#title'],
             '#submit' => [
               'webform_strawberryfield_go_to_page',
             ],

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -24,6 +24,7 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
 
   /** @var \Drupal\webform\WebformSubmissionForm $submission_form */
   $submission_form = $form_state->getFormObject();
+  $form['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.nodeactions.toggle';
 
   if (strpos($form_id, 'webform_submission') === 0
     && $submission_form instanceof WebformSubmissionForm) {
@@ -355,4 +356,31 @@ function _update_file_usage(\Drupal\File\FileInterface $file, int $nodeid) {
       }
       $file_usage->add($file, 'strawberryfield', 'node', $nodeid);
   }
+}
+
+
+function webform_strawberryfield_form_node_form_alter(&$form, FormStateInterface &$form_state, $form_id) {
+  //$node = $form_state->getFormObject()->getEntity();
+  // Means this form has a webform widget
+
+  if (isset($form_state->getStorage()['webform_machine_name'])){
+    $input = $form_state->getUserInput();
+
+    if ((!isset($input['_triggering_element_name'])) || (isset($input['_triggering_element_value']) && $input['_triggering_element_value']!='Save Metadata')) {
+      foreach ($form['actions'] as $key => &$buttons) {
+        if ($key == 'delete') {
+          $buttons['#access'] = FALSE;
+        }
+        if ($key == 'submit') {
+          $buttons['#attributes']['class'][] = 'hidden';
+        }
+      }
+    }
+    else {
+
+
+    }
+  }
+
+
 }

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -28,12 +28,10 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
   if (strpos($form_id, 'webform_submission') === 0
     && $submission_form instanceof WebformSubmissionForm) {
 
-    $query = \Drupal::request()->query->all();
-
     // @TODO check if we should use instead \Drupal\webform\WebformSubmissionForm::isAjax
     // I'm not totally convinced since we could be "ajaxifying" a webform here
     // that was not set as such in it's saved settings.
-    $is_ajax = (!empty($query['ajax_form'])) ? TRUE : FALSE;
+
 
     /** @var  \Drupal\webform\Entity\WebformSubmission $webform_submission */
     $webform_submission = $submission_form->getEntity();
@@ -55,11 +53,16 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
       $form['actions']['reset']['#submit'] = ['webform_strawberryfield_widget_reset'];
     }
 
-    // add a close model button
+
+
+
+    /* @TODO make this a valid switch
+     // We should not make close object available if inline
+     // add a close model button
+    $query = \Drupal::request()->query->all();
+    $is_ajax = (!empty($query['ajax_form'])) ? TRUE : FALSE;
     $webform_close_controller_url = Url::fromRoute(
-      'webform_strawberryfield.close_modal_webform'
-    );
-    // Also @see https://drupal.stackexchange.com/questions/184390/how-to-perform-action-from-form-opened-in-modal
+    'webform_strawberryfield.close_modal_webform');
     if ($is_ajax) {
       $form['actions']['closemodal'] = [
         '#type' => 'link',
@@ -73,7 +76,7 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
         ],
         '#weight' => 100,
       ];
-    }
+    }*/
 
     if ($form_state->get('current_page') === 'webform_preview') {
       /** @var \Drupal\webform\WebformSubmissionForm $submission_form */
@@ -86,7 +89,6 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
             '#value' => 'edit '.$key,
             '#submit' => [
               'webform_strawberryfield_go_to_page',
-              //[$submission_form, 'previous']
             ],
             '#attributes' => [
               'class' => ['js-webform-novalidate'],


### PR DESCRIPTION
This pull makes sure
* that inline webforms used as Widgets for a Strawberry field behave better.
* It also adds an experimental, JS only, hidding/show of the node submit button.  This needs more work to be bullet proof and discussion can happen to move this to a theming layer (or a toggle) instead of directly to a hardcoded decision. 
* It removes the close button since we are moving away (for now) of having a Modal Dialog for the webform as @natehill requested during its UI simplification. 