### PR TITLE
Toggle Node submit actions visibilty if moderation state or title is …

### DIFF
--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -25,7 +25,24 @@
                 } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
                     $('.path-node div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
                 }
+
+
+                var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
+                if ($moderationstate.length) {
+
+                    var $select = $moderationstate.on('change', function () {
+                        $('.path-node div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
+
+                    });
+                }
+                var $nodetitle = $('input[data-drupal-selector="edit-title-0-value"]', context).once('show-hide-actions');
+                if ($nodetitle.length) {
+                    var $select = $nodetitle.on('input', function () {
+                        $('.path-node div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
+
+                    });
+                }
             }
         }
-    };
+    }
 })(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
This adds some extra JS to the humble attempt of declutter object ingest worklow by re-cluttering it again, if someone needs to just change the title or the moderation state of an Object, basically showing node actions if that happens.
TODO: really document the use cases and why we are doing this. Decluttering per se can not be the only motivator here and it needs to respond to the actual worklow
TODO2: bring this into a JS setting per field widget, so people can deactivate this functionality if needed.

@natehill @giancarlobi 