### PR TITLE
ISSUE-7: Deal with empty $form elements for Webform Ingest steps

### DIFF
--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -84,7 +84,7 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
       $submission_form = $form_state->getFormObject();
 
       foreach ($form['elements'] as $key => &$element) {
-        if ($element['#type'] == 'webform_wizard_page') {
+        if (isset($element['#type']) && ($element['#type'] == 'webform_wizard_page')) {
           $form['actions']['edit_wizard_page_'.$key][] = [
             '#type' => 'submit',
             '#value' => 'edit '.$element['#title'],


### PR DESCRIPTION
# What does this pull do?

See #17 
 
Adds a simple check for the existance of a `#type` key on our webform alter hook. This part of the code just deals with adding diret link buttons to each webform step to allow people to go directly to a certain step and make corrections before Saving metadata, when on the final preview step. When this fails Webform data never gets persisted to the private storage used to keep values around.

This is something new and seems to be triggered by some change in Webform 5.2 >

# How to test

Pull this branch or apply a patch to your webform strawberryfield.
Ingest a new Object, follow every step, press "Preview" before saving metadata. Once there, press "Save Metadata".  Save the Node. All values should be visible and present.

@giancarlobi just so you know this is being merged into 8.x-1.0-beta1. I will also add a new `update.sh` script and instructions to archipelago-deployment to make sure people have a simple way of upgrading/testing latest code before we freeze the code without having to deal with complicated composer updates manually.
