### PR TITLE
ISSUE-20: SearchAPI/Views driven Entity Reference Autocomplete

### DIFF
--- a/src/Plugin/EntityReferenceSelection/ViewsSolrSelection.php
+++ b/src/Plugin/EntityReferenceSelection/ViewsSolrSelection.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/19/19
+ * Time: 6:42 PM
+ */
+
+namespace Drupal\webform_strawberryfield\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\DependencyInjection\DeprecatedServicePropertyTrait;
+use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Language\LanguageInterface;
+
+/**
+ * Plugin implementation of the 'selection' entity_reference.
+ *
+ * @EntityReferenceSelection(
+ *   id = "solr_views",
+ *   label = @Translation("Views Solr: Filter by an entity reference view"),
+ *   entity_types = {"node"},
+ *   group = "solr_views",
+ *   weight = 1
+ * )
+ */
+class ViewsSolrSelection extends SelectionPluginBase implements ContainerFactoryPluginInterface {
+
+  use DeprecatedServicePropertyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $deprecatedProperties = ['entityManager' => 'entity.manager'];
+
+  /**
+   * The loaded View object.
+   *
+   * @var \Drupal\views\ViewExecutable
+   */
+  protected $view;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new ViewsSelection object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    ModuleHandlerInterface $module_handler,
+    AccountInterface $current_user
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('module_handler'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+        'view' => [
+          'view_name' => NULL,
+          'display_name' => NULL,
+          'arguments' => [],
+        ],
+      ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(
+    array $form,
+    FormStateInterface $form_state
+  ) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $view_settings = $this->getConfiguration()['view'];
+    $displays = Views::getApplicableViews('entity_reference_display');
+    // Filter views that list the entity type we want, and group the separate
+    // displays by view.
+    // $entity_type = $this->entityTypeManager->getDefinition($this->configuration['target_type']);
+    $view_storage = $this->entityTypeManager->getStorage('view');
+
+    $options = [];
+    foreach ($displays as $data) {
+      list($view_id, $display_id) = $data;
+      $view = $view_storage->load($view_id);
+      $display = $view->get('display');
+      $options[$view_id . ':' . $display_id] = $view_id . ' - ' . $display[$display_id]['display_title'];
+    }
+
+    // The value of the 'view_and_display' select below will need to be split
+    // into 'view_name' and 'view_display' in the final submitted values, so
+    // we massage the data at validate time on the wrapping element (not
+    // ideal).
+    $form['view']['#element_validate'] = [
+      [
+        get_called_class(),
+        'settingsFormValidate',
+      ],
+    ];
+
+    if ($options) {
+      $default = !empty($view_settings['view_name']) ? $view_settings['view_name'] . ':' . $view_settings['display_name'] : NULL;
+      $form['view']['view_and_display'] = [
+        '#type' => 'select',
+        '#title' => $this->t('View used to select the entities'),
+        '#required' => TRUE,
+        '#options' => $options,
+        '#default_value' => $default,
+        '#description' => '<p>' . $this->t(
+            'Choose the view and display that select the entities that can be referenced.<br />Only views with a display of type "Entity Reference" are eligible.'
+          ) . '</p>',
+      ];
+
+      $default = !empty($view_settings['arguments']) ? implode(
+        ', ',
+        $view_settings['arguments']
+      ) : '';
+      $form['view']['arguments'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('View arguments'),
+        '#default_value' => $default,
+        '#required' => FALSE,
+        '#description' => $this->t(
+          'Provide a comma separated list of arguments to pass to the view.'
+        ),
+      ];
+    }
+    else {
+      if ($this->currentUser->hasPermission(
+          'administer views'
+        ) && $this->moduleHandler->moduleExists('views_ui')) {
+        $form['view']['no_view_help'] = [
+          '#markup' => '<p>' . $this->t(
+              'No eligible views were found. <a href=":create">Create a view</a> with an <em>Entity Reference</em> display, or add such a display to an <a href=":existing">existing view</a>.',
+              [
+                ':create' => Url::fromRoute('views_ui.add')->toString(),
+                ':existing' => Url::fromRoute('entity.view.collection')
+                  ->toString(),
+              ]
+            ) . '</p>',
+        ];
+      }
+      else {
+        $form['view']['no_view_help']['#markup'] = '<p>' . $this->t(
+            'No eligible views were found.'
+          ) . '</p>';
+      }
+    }
+    return $form;
+  }
+
+  /**
+   * Initializes a view.
+   *
+   * @param string|null $match
+   *   (Optional) Text to match the label against. Defaults to NULL.
+   * @param string $match_operator
+   *   (Optional) The operation the matching should be done with. Defaults
+   *   to "CONTAINS".
+   * @param int $limit
+   *   Limit the query to a given number of items. Defaults to 0, which
+   *   indicates no limiting.
+   * @param array|null $ids
+   *   Array of entity IDs. Defaults to NULL.
+   *
+   * @return bool
+   *   Return TRUE if the view was initialized, FALSE otherwise.
+   */
+  protected function initializeView(
+    $match = NULL,
+    $match_operator = 'CONTAINS',
+    $limit = 0,
+    $ids = NULL
+  ) {
+    $view_name = $this->getConfiguration()['view']['view_name'];
+    $display_name = $this->getConfiguration()['view']['display_name'];
+
+    // Check that the view is valid and the display still exists.
+    $this->view = Views::getView($view_name);
+    if (!$this->view || !$this->view->access($display_name)) {
+      \Drupal::messenger()->addWarning(
+        t(
+          'The reference view %view_name cannot be found.',
+          ['%view_name' => $view_name]
+        )
+      );
+      return FALSE;
+    }
+
+    $this->view->setDisplay($display_name);
+
+    // Pass options to the display handler to make them available later.
+    // We can not pass 'match' as option since \Drupal\views\Plugin\views\display\EntityReference::query
+    // Tries to deal with this as it was an SQL Query!
+    $lang_code = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    // We are aiming at LoD here. We want to allow other than default language
+    // To be valid too.
+    $ids_solr = NULL;
+    if (!empty($ids)) {
+      foreach ($ids as $id) {
+        $ids_solr[] = 'entity:node/' . $id . ':' . $lang_code;
+        $ids_solr[] = 'entity:node/' . $id . ':' . 'en';
+        $ids_solr[] = 'entity:node/' . $id . ':' . LanguageInterface::LANGCODE_NOT_SPECIFIED;
+        $ids_solr[] = 'entity:node/' . $id . ':' . LanguageInterface::LANGCODE_NOT_APPLICABLE;
+      }
+      // Remove doubles.
+      $ids_solr = array_unique($ids_solr);
+    }
+
+    $entity_reference_options = [
+      'match_operator_solr' => $match_operator,
+      'match_solr' => $match,
+      'limit' => $limit,
+      'ids_solr' => $ids_solr,
+      'ids' => $ids,
+    ];
+
+    $this->view->displayHandlers->get($display_name)->setOption(
+      'entity_reference_options',
+      $entity_reference_options
+    );
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getReferenceableEntities(
+    $match = NULL,
+    $match_operator = 'CONTAINS',
+    $limit = 0
+  ) {
+    $display_name = $this->getConfiguration()['view']['display_name'];
+    $arguments = $this->getConfiguration()['view']['arguments'];
+    $result = [];
+
+    if ($this->initializeView($match, $match_operator, $limit)) {
+      $result = $this->view->executeDisplay($display_name, $arguments);
+    }
+
+    $return = [];
+    if ($result) {
+      foreach ($this->view->result as $row) {
+        /* @var $entityadapter \Drupal\Core\Entity\Plugin\DataType\EntityAdapter */
+        $entityadapter = $row->_object;
+        $entity = $entityadapter->getValue();
+        $return[$entity->bundle()][$entity->id()] = $entity->label();
+      }
+    }
+    return $return;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function countReferenceableEntities(
+    $match = NULL,
+    $match_operator = 'CONTAINS'
+  ) {
+    $this->getReferenceableEntities($match, $match_operator);
+    return $this->view->pager->getTotalItems();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateReferenceableEntities(array $ids) {
+    $display_name = $this->getConfiguration()['view']['display_name'];
+    $arguments = $this->getConfiguration()['view']['arguments'];
+    $result = [];
+    if ($this->initializeView(NULL, 'CONTAINS', 0, $ids)) {
+      // Get the results.
+      $entities = $this->view->executeDisplay($display_name, $arguments);
+      $result = array_keys($entities);
+      foreach ($result as &$id) {
+        // We want to convert entity:node/9:en into 9
+        $parts = explode(':', str_replace('entity:node/', '', $id));
+        $id = $parts[0];
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * Element validate; Check View is valid.
+   */
+  public static function settingsFormValidate(
+    $element,
+    FormStateInterface $form_state,
+    $form
+  ) {
+    // Split view name and display name from the 'view_and_display' value.
+    if (!empty($element['view_and_display']['#value'])) {
+      list($view, $display) = explode(
+        ':',
+        $element['view_and_display']['#value']
+      );
+    }
+    else {
+      $form_state->setError(
+        $element,
+        t('The views entity selection mode requires a view.')
+      );
+      return;
+    }
+
+    // Explode the 'arguments' string into an actual array. Beware, explode()
+    // turns an empty string into an array with one empty string. We'll need an
+    // empty array instead.
+    $arguments_string = trim($element['arguments']['#value']);
+    if ($arguments_string === '') {
+      $arguments = [];
+    }
+    else {
+      // array_map() is called to trim whitespaces from the arguments.
+      $arguments = array_map('trim', explode(',', $arguments_string));
+    }
+
+    $value = [
+      'view_name' => $view,
+      'display_name' => $display,
+      'arguments' => $arguments,
+    ];
+    $form_state->setValueForElement($element, $value);
+  }
+
+}

--- a/src/Plugin/views/display/EntityReference.php
+++ b/src/Plugin/views/display/EntityReference.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/20/19
+ * Time: 2:19 PM
+ */
+
+namespace Drupal\webform_strawberryfield\Plugin\views\display;
+
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\search_api\Query\Condition;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * The plugin that handles an EntityReference display for Solr Search API.
+ *
+ * "entity_reference_display" is a custom property, used with
+ * \Drupal\views\Views::getApplicableViews() to retrieve all views with a
+ * 'Entity Reference' display.
+ *
+ * This View Display applies only to search_api_index_default_solr_index
+ *
+ * @ingroup views_display_plugins
+ *
+ * @ViewsDisplay(
+ *   id = "entity_reference_solr",
+ *   title = @Translation("Solr Search API Entity Reference"),
+ *   admin = @Translation("Solr Search API Entity Reference Source"),
+ *   help = @Translation("Selects reference-able entities for an entity reference field via the Solr Search API."),
+ *   theme = "views_view",
+ *   base = {
+ *   "search_api_index_default_solr_index"
+ *   },
+ *   register_theme = FALSE,
+ *   uses_menu_links = FALSE,
+ *   entity_reference_display = TRUE
+ * )
+ */
+class EntityReference extends DisplayPluginBase {
+
+  /**x
+   * {@inheritdoc}
+   */
+  protected $usesAJAX = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesPager = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesAttachments = FALSE;
+
+  /**
+   * Constructs a new EntityReference object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    // Force the style plugin to 'entity_reference_style' and the row plugin to
+    // 'fields'.
+    $options['style']['contains']['type'] = ['default' => 'entity_reference'];
+    $options['defaults']['default']['style'] = FALSE;
+    $options['row']['contains']['type'] = ['default' => 'entity_reference'];
+    $options['defaults']['default']['row'] = FALSE;
+
+    // Set the display title to an empty string (not used in this display type).
+    $options['title']['default'] = '';
+    $options['defaults']['default']['title'] = FALSE;
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function optionsSummary(&$categories, &$options) {
+    parent::optionsSummary($categories, $options);
+    // Disable 'title' so it won't be changed from the default set in
+    // \Drupal\views\Plugin\views\display\EntityReference::defineOptions.
+    unset($options['title']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return 'entity_reference';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    return $this->view->render($this->display['id']);
+  }
+
+  /**
+   * Builds the view result as a renderable array.
+   *
+   * @return array
+   *   Renderable array or empty array.
+   */
+  public function render() {
+    if (!empty($this->view->result) && $this->view->style_plugin->evenEmpty()) {
+      return $this->view->style_plugin->render($this->view->result);
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usesExposed() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Make sure the id field is included in the results.
+    // @see \Drupal\search_api\Plugin\views\ResultRow::$lazyLoad
+    // "search_api_id" is always the base field id that gets lazy resolved
+    // against the getId() == entity->id on result rows.
+    // But that means you can not filter against it using directly the id int.
+    // Means our id's passed by \Drupal\webform_strawberryfield\Plugin\EntityReferenceSelection\ViewsSolrSelection
+    // Need to have that form too.
+    $id_field = $this->view->storage->get('base_field');
+    $id_table = $this->view->storage->get('base_table');
+
+    // This is weird. Since this extends DisplayPluginBase and viewsexecutable
+    // Assumes that the $query is of a base type instead extending an interface
+    // The Dev IDE gets can not access the real properties we have at hand
+    // For this specific type of query. So this helps.
+    /* @var $search_api_query \Drupal\search_api\Plugin\views\query\SearchApiQuery */
+    $search_api_query = $this->view->query;
+
+    $this->id_field_alias = $this->view->query->addField($id_table, $id_field);
+    if (!empty($this->view->live_preview)) {
+      // We hate blind Views on the UI. Give it a starting Match so we can
+      // see the logic happening
+    }
+
+    // Make sure the id field is included in the results.
+    $id_field = $this->view->storage->get('base_field');
+    $id_table = $this->view->storage->get('base_table');
+    $this->id_field_alias = $search_api_query->addField($id_table, $id_field);
+
+    $options = $this->getOption('entity_reference_options');
+    // Restrict the autocomplete options based on what's been typed already.
+    if (isset($options['match_solr'])) {
+      $style_options = $this->getOption('style');
+      // See if we need to use some escape mechanism from here
+      // @see \Drupal\search_api_solr\Utility\Utility
+      $value = $options['match_solr'];
+      if ($options['match_operator_solr'] !== '=') {
+        $value = $value . '%';
+        if ($options['match_operator_solr'] != 'STARTS_WITH') {
+          $value = '%' . $value;
+        }
+      }
+
+      // Multiple search fields are OR'd together.
+      $match_condition_group = $search_api_query->createConditionGroup('OR');
+
+      // we can't use $field_id as field.
+      // We need to resolve it back to its original Solr field.
+      // Build the condition using the selected search fields.
+      foreach ($style_options['options']['search_fields'] as $field_id) {
+        if (!empty($field_id)) {
+          $realfieldname = $this->getHandlers('field')[$field_id]->field;
+          // Add an OR condition for the field.
+          // We use = operator since we expect fields to be ngrams indexed
+          $match_condition_group->addCondition($realfieldname, $value, '=');
+        }
+      }
+
+      $search_api_query->addConditionGroup($match_condition_group, 'MATCH');
+    }
+    // Add an IN condition for validation.
+    if (!empty($options['ids_solr'])) {
+      $search_api_query->addWhere(0, $id_field, $options['ids_solr'], 'IN');
+    }
+    $this->view->setItemsPerPage($options['limit']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate() {
+    $errors = parent::validate();
+    // Verify that search fields are set up.
+    $style = $this->getOption('style');
+    if (!isset($style['options']['search_fields'])) {
+      $errors[] = $this->t('Display "@display" needs a selected search fields to work properly. See the settings for the Entity Reference list format.', ['@display' => $this->display['display_title']]);
+    }
+    else {
+      // Verify that the search fields used actually exist.
+      $fields = array_keys($this->handlers['field']);
+      foreach ($style['options']['search_fields'] as $field_alias => $enabled) {
+        if ($enabled && !in_array($field_alias, $fields)) {
+          $errors[] = $this->t('Display "@display" uses field %field as search field, but the field is no longer present. See the settings for the Entity Reference list format.', ['@display' => $this->display['display_title'], '%field' => $field_alias]);
+        }
+      }
+    }
+    return $errors;
+  }
+
+}


### PR DESCRIPTION
# What is new?

See #20 

This adds two new plugins, to allow Drupal to use Views driven by SearchAPI as source for entity reference Autocompletes. This way we can filter in a much better and powerful way what entities can be used  in fields like childOf, sceneOf, relatedTo, foaf, etc by having a total fine grained control on filtering Entities by any SBF JSON keys and values indexed in Solr. It also allows our repository to scale way beyond the performance limitations of SQL making autocomplete even possible in realtime on repos with millions of records.

# How to test?

I will follow up with a demo View to be used in an Entity Reference Autocomplete field, and also a Webform setup to use this. The webform will allow, for that element to pass also an extra argument to filter by SBF JSON key "type" which is our equivalent of rdf:type.

@giancarlobi. Will discuss with you what is the best option for publishing that Drupal View. I think i will add that one in a second commit to this pull as a fixed, installed via an hook_update so we can always depend on its existence. People will be able to clone, or make their own, since the new Views Display Mode can be used on any SearchAPI driven View but is not allowed (nice!) for SQL driven ones, since Drupal already provides one for that.