### PR TITLE
ISSUE-28: Add reverse method to NominatimController.php

### DIFF
--- a/src/Controller/NominatimController.php
+++ b/src/Controller/NominatimController.php
@@ -122,6 +122,8 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
   }
 
   /**
+   * Takes lat/long and returns a single address from Nominatim API.
+   * 
    * @param $lat
    * @param $lon
    * @param string $lang
@@ -185,7 +187,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
       }
       return  $results;
     }
-    \Drupal::messenger()->addError(
+    $this->messenger()->addError(
       $this->t('Looks like data fetched from @url with query options: @options is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
         [
           '@url' => $remoteUrl,
@@ -210,7 +212,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
       return [];
     }
     if (!UrlHelper::isValid($remoteUrl, $absolute = TRUE)) {
-      \Drupal::messenger()->addError(
+      $this->messenger()->addError(
         $this->t('We can not fetch Data from @remoteUrl with query @options, check your URL',
           [
             '@remoteUrl' =>  $remoteUrl,
@@ -227,7 +229,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
     }
     catch(ClientException $exception) {
       $responseMessage = $exception->getMessage();
-      \Drupal::messenger()->addError(
+      $this->messenger()->addError(
         $this->t('We tried to contact @url with query @options but we could not. <br> The WEB says: @response. <br> Check that URL!',
           [
             '@url' => $remoteUrl,

--- a/src/Controller/NominatimController.php
+++ b/src/Controller/NominatimController.php
@@ -61,7 +61,6 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    */
   public function handleRequest(Request $request, $api_type = 'search', $count = 5, string $lang = '') {
-    $results = [];
     //@TODO pass count to the actual fetchers
     //@TODO maybe refactor into plugins so others can write any other reconciliators
     //@TODO if so, we can query the plugins and show in the webform builder options

--- a/src/Controller/NominatimController.php
+++ b/src/Controller/NominatimController.php
@@ -30,7 +30,6 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
    */
   protected $httpClient;
 
-
   /**
    * NominatimController constructor.
    *
@@ -43,7 +42,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
   /**
    * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
    *
-   * @return \Drupal\Core\Controller\ControllerBase|\Drupal\webform_strawberryfield\Controller\AuthAutocompleteController
+   * @return \Drupal\Core\Controller\ControllerBase|\Drupal\webform_strawberryfield\Controller\NominatimController
    */
   public static function create(ContainerInterface $container) {
     return new static(
@@ -57,6 +56,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
    * @param \Symfony\Component\HttpFoundation\Request $request
    * @param $api_type
    * @param $count
+   * @param string $lang
    *
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    */
@@ -68,16 +68,21 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
     // Get the typed string from the URL, if it exists.
     $lang = !empty($lang) ? trim($lang) : $this->languageManager()->getCurrentLanguage()->getId();
     $results = [];
-    if ($input = $request->query->get('q')) {
-      switch($api_type) {
-        case 'search':  $results = $this->search($input,$count, $lang);
-        break;
-        case 'reverse': $results =  $this->reverse($input,$count, $lang);
-        break;
-      }
 
-
-    }
+    // Switch on api_type, because queries will have different keys. But still check keys.
+    switch($api_type) {
+        case 'search':
+          if ($input = $request->query->get('q')) {
+            $results = $this->search($input, $count, $lang);
+          }
+          break;
+        case 'reverse':
+          if (($lat = $request->query->get('lat')) && ($lon = $request->query->get('lon'))) {
+            $results = $this->reverse($lat, $lon, $lang);
+          }
+          break;
+     }
+      
     // Add Cache settings for Max-age and URL context.
     // You can use any of Drupal's contexts, tags, and time.
    /* $results['#cache'] = [
@@ -103,7 +108,6 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
   protected function search($input, int $count = 5, string $lang = 'en'){
     // The request we are going to do is something like
     // "https://nominatim.openstreetmap.org/search?q=West+87th+Street,NY&limit=5&format=geojson&addressdetails=1";
-
     $remoteUrl = 'https://nominatim.openstreetmap.org/search';
 
     $options['headers']=['Accept' => 'application/json', 'Accept-Language' => $lang];
@@ -113,6 +117,42 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
       'format' => 'geojson',
       'addressdetails' => 1
     ];
+    
+    return $this->processRequest($remoteUrl, $options);
+  }
+
+  /**
+   * @param $lat
+   * @param $lon
+   * @param string $lang
+   *
+   * @return array
+   */
+  public function reverse($lat, $lon, string $lang = 'en'){
+    // The request we are going to do is something like
+    // "https://nominatim.openstreetmap.org/reverse?format=geojson&lat=44.50155&lon=11.33989";
+    $remoteUrl = 'https://nominatim.openstreetmap.org/reverse';
+
+    $options['headers']=['Accept' => 'application/json', 'Accept-Language' => $lang];
+    $options['query'] = [
+      'lat' => $lat,
+      'lon' => $lon,
+      'format' => 'geojson',
+      'addressdetails' => 1
+    ];
+    
+    return $this->processRequest($remoteUrl, $options);
+  }
+
+  /**
+   * Sends given request with options, returns results, and adds errors to messenger service.
+   * 
+   * @param $remoteUrl
+   * @param $options
+   *
+   * @return array|
+   */
+  protected function processRequest($remoteUrl, $options) {
     // Add an artificial delay of 1 second to aid in
     // https://operations.osmfoundation.org/policies/nominatim/
     sleep(1);
@@ -138,14 +178,14 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
       }
       else {
         // Means our call was correct, but nominatim failed. Could be temporary?
-          $results[] = [
-            'value' => NULL,
-            'label' => 'Sorry https://nominatim.openstreetmap.org responsed with an error. Please Try again'
-          ];
-        }
+        $results[] = [
+          'value' => NULL,
+          'label' => 'Sorry https://nominatim.openstreetmap.org responsed with an error. Please Try again'
+        ];
+      }
       return  $results;
     }
-    $this->messenger->addError(
+    \Drupal::messenger()->addError(
       $this->t('Looks like data fetched from @url with query options: @options is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
         [
           '@url' => $remoteUrl,
@@ -156,8 +196,6 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
     );
     return [];
   }
-
-
 
   /**
    * @param $remoteUrl
@@ -172,7 +210,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
       return [];
     }
     if (!UrlHelper::isValid($remoteUrl, $absolute = TRUE)) {
-      $this->messenger->addError(
+      \Drupal::messenger()->addError(
         $this->t('We can not fetch Data from @remoteUrl with query @options, check your URL',
           [
             '@remoteUrl' =>  $remoteUrl,
@@ -189,7 +227,7 @@ class NominatimController extends ControllerBase implements ContainerInjectionIn
     }
     catch(ClientException $exception) {
       $responseMessage = $exception->getMessage();
-      $this->messenger->addError(
+      \Drupal::messenger()->addError(
         $this->t('We tried to contact @url with query @options but we could not. <br> The WEB says: @response. <br> Check that URL!',
           [
             '@url' => $remoteUrl,

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -19,15 +19,7 @@ webform_strawberryfield.auth_autocomplete:
   requirements:
     _access: 'TRUE'
 webform_strawberryfield.nominatim:
-  path: '/webform_strawberry/nominatim/{api_type}/{count}/{lang}'
-  defaults:
-    _controller: '\Drupal\webform_strawberryfield\Controller\NominatimController::handleRequest'
-    _format: json
-  requirements:
-    _permission: 'access content'
-    _csrf_token: 'TRUE'
-webform_strawberryfield.nominatim_reverse:
-  path: '/webform_strawberry/nominatim/{api_type}/{lang}'
+  path: '/webform_strawberry/nominatim/{api_type}/{count<\d+>?5}/{lang}'
   defaults:
     _controller: '\Drupal\webform_strawberryfield\Controller\NominatimController::handleRequest'
     _format: json

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -19,10 +19,12 @@ webform_strawberryfield.auth_autocomplete:
   requirements:
     _access: 'TRUE'
 webform_strawberryfield.nominatim:
-  path: '/webform_strawberry/nominatim/{api_type}/{count<\d+>?5}/{lang}'
+  path: '/webform_strawberry/nominatim/{api_type}/{lang}/{count}'
   defaults:
     _controller: '\Drupal\webform_strawberryfield\Controller\NominatimController::handleRequest'
     _format: json
+    count: 1
   requirements:
     _permission: 'access content'
     _csrf_token: 'TRUE'
+    count: '\d+'

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -26,3 +26,11 @@ webform_strawberryfield.nominatim:
   requirements:
     _permission: 'access content'
     _csrf_token: 'TRUE'
+webform_strawberryfield.nominatim_reverse:
+  path: '/webform_strawberry/nominatim/{api_type}/{lang}'
+  defaults:
+    _controller: '\Drupal\webform_strawberryfield\Controller\NominatimController::handleRequest'
+    _format: json
+  requirements:
+    _permission: 'access content'
+    _csrf_token: 'TRUE'


### PR DESCRIPTION
This pull addresses #28 

### What is new?
- Method allows reverse lookup of an address given lat and long
- Add correct call to method in NominatimController->handleRequest
- Create NominatimController::processRequest method to share code between search and reverse
- Add route webform_strawberryfield.nominatim_reverse because of different route params
- Replace broken calls to $this->messenger with static \Drupal::messenger

### Testing
Call the method. I did this via command line. I also made sure it worked inside `handleRequest`

- `handleRequest` receives a fully formed Request object from a form submit, which then gets used for arguments when it calls `::search`. If you want to test a properly formatted request with `reverse`, here is some code I used (modified from the WebformNominatim #submit callback). Change the values of lat and long around to words, 0, empty, and see the errors.
```
$test_reverse_url = Url::fromRoute(
  'webform_strawberryfield.nominatim_reverse',
  ['api_type' => 'reverse', 'lang' => 'en'],
  ['query' => ['lat' => “44.50155”, 'lon'=> "11.33989"]]
);

$test_reverse_request = Request::create($test_reverse_url->toString(),'GET');
```

### Notes:
- `reverse` has a different parameters than `::search`. No $count. No $input. Yes $lat, $lon.
- Using the static \Drupal::messenger(). I tried injecting it with dependency first. But with the changed signature, when making a new NominatimController in WebformNominatim.php, I wasn't able to pass \Drupal::messenger() easily, because that returns something of type LegacyMessenger. So I decided not to change the arguments of NominatimController for now, but welcome advice on dealing with legacy Drupal code. Probably I missed something. I also remembered your advice @DiegoPino  not to change signatures of public functions.