### PR TITLE
ISSUE-33: Add missing schema

### DIFF
--- a/config/schema/webform_strawberryfield.schema.yml
+++ b/config/schema/webform_strawberryfield.schema.yml
@@ -24,12 +24,13 @@ field.widget.settings.strawberryfield_webform_widget:
     rows:
       type: integer
       label: 'Rows'
-# see field.widget.settings.webform_entity_reference_autocomplete
-# match_limit should already exist in schema but getting missing schema error.
-#field.widget.settings.webform_entity_reference_autocomplete:
-#  type: mapping
-#  label: 'Webform Entity Reference Autocomplete Schema'
-#  mapping:
-#    match_limit:
-#      type: integer
-#      label: 'Match Limit'
+field.widget.settings.webform_entity_reference_autocomplete:
+  type: field.widget.settings.entity_reference_autocomplete
+  label: 'Webform Entity Reference Autocomplete Schema'
+  mapping:
+    match_limit:
+      type: integer
+      label: 'Match Limit'
+    default_data:
+      type: boolean
+      label: 'Default Data'

--- a/config/schema/webform_strawberryfield.schema.yml
+++ b/config/schema/webform_strawberryfield.schema.yml
@@ -1,0 +1,35 @@
+field.widget.settings.strawberryfield_webform_inline_widget:
+  type: config_object
+  label: 'Webform Inline Widget Schema'
+  mapping:
+    placeholder:
+      type: string
+      label: 'Placeholder'
+    webform_id:
+      type: string
+      label: 'Webform ID'
+    rows:
+      type: integer
+      label: 'Rows'
+field.widget.settings.strawberryfield_webform_widget:
+  type: config_object
+  label: 'Webform Inline Widget Schema'
+  mapping:
+    placeholder:
+      type: string
+      label: 'Placeholder'
+    webform_id:
+      type: string
+      label: 'Webform ID'
+    rows:
+      type: integer
+      label: 'Rows'
+# see field.widget.settings.webform_entity_reference_autocomplete
+# match_limit should already exist in schema but getting missing schema error.
+#field.widget.settings.webform_entity_reference_autocomplete:
+#  type: mapping
+#  label: 'Webform Entity Reference Autocomplete Schema'
+#  mapping:
+#    match_limit:
+#      type: integer
+#      label: 'Match Limit'


### PR DESCRIPTION
! This is a work in progress ! addressing #33 

Fixed are:
core.entity_form_display.metadatadisplay_entity.metadatadisplay_entity.default
core.entity_form_display.node.digital_object.super_admin_raw_json

There were several schemas I had problems with.
I will organize them by the errors showing in http://localhost:8001/admin/reports/status

webform.webform.descriptive_metadata
  - This is the issue of the harvester spacing ID previously discussed with @DiegoPino 
`id = " strawberryField_webform_handler"`

core.entity_form_display.node.webform.default
  - This is commented out in my pull here. `field.widget.settings.webform_entity_reference_autocomplete` with `match_limit` should already be set, but we are getting missing schema for a reason I don't understand
