### PR TITLE
ISSUE-39: First pass on better Panorama Tour builder UI

### DIFF
--- a/js/scenebuilder-pannellum_strawberryfield.js
+++ b/js/scenebuilder-pannellum_strawberryfield.js
@@ -53,9 +53,9 @@
             $scene = Drupal.FormatStrawberryfieldPanoramas.panoramas.get($targetScene);
             // add click handlers for new Hotspots if they have an URL.
             // Empty URLs are handled by Drupal.FormatStrawberryfieldhotspotPopUp()
-            console.log(response.hotspotid);
-            console.log(response.sceneid);
-            $scene.panorama.removeHotSpot(response.hotspotid, response.sceneid);
+            console.log(response);
+            $scene.panorama.removeHotSpot(response.hotspotid.id);
+            console.log("removing hotspot with id " +response.hotspotid.id);
         }
     };
 

--- a/js/scenebuilder-pannellum_strawberryfield.js
+++ b/js/scenebuilder-pannellum_strawberryfield.js
@@ -43,6 +43,25 @@
     };
 
 
+    Drupal.AjaxCommands.prototype.webform_strawberryfield_pannellum_editor_removeHotSpot = function(ajax, response, status) {
+        console.log('removing hotspot');
+        // we need to find the first  '.strawberry-panorama-item' id that is child of data-drupal-selector="edit-panorama-tour-hotspots"
+        console.log(response.selector);
+        $targetScene = $(response.selector).find('.strawberry-panorama-item').attr("id");
+        console.log($targetScene);
+        if (response.hasOwnProperty('hotspotid') && response.hasOwnProperty('sceneid')) {
+            $scene = Drupal.FormatStrawberryfieldPanoramas.panoramas.get($targetScene);
+            // add click handlers for new Hotspots if they have an URL.
+            // Empty URLs are handled by Drupal.FormatStrawberryfieldhotspotPopUp()
+            console.log(response.hotspotid);
+            console.log(response.sceneid);
+            $scene.panorama.removeHotSpot(response.hotspotid, response.sceneid);
+        }
+    };
+
+
+
+
     Drupal.behaviors.webform_strawberryfield_pannellum_editor = {
         attach: function(context, settings) {
             $('.strawberry-panorama-item[data-iiif-image]').once('attache_pne')

--- a/js/scenebuilder-pannellum_strawberryfield.js
+++ b/js/scenebuilder-pannellum_strawberryfield.js
@@ -54,8 +54,8 @@
             // add click handlers for new Hotspots if they have an URL.
             // Empty URLs are handled by Drupal.FormatStrawberryfieldhotspotPopUp()
             console.log(response);
-            $scene.panorama.removeHotSpot(response.hotspotid.id);
-            console.log("removing hotspot with id " +response.hotspotid.id);
+            $scene.panorama.removeHotSpot(response.hotspotid);
+            console.log("removing hotspot with id " +response.hotspotid);
         }
     };
 

--- a/src/Ajax/RemoveHotSpotCommand.php
+++ b/src/Ajax/RemoveHotSpotCommand.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 10/1/19
+ * Time: 11:30 AM
+ */
+
+namespace Drupal\webform_strawberryfield\Ajax;
+use Drupal\Core\Ajax\CommandInterface;
+class RemoveHotSpotCommand implements CommandInterface
+{
+
+  /**
+   * The Hotspot ID
+   *
+   * @var string;
+   */
+  protected $hotspotid;
+
+
+  /**
+   * The Scene ID
+   *
+   * @var string
+   */
+  protected $sceneid;
+
+  /**
+   * The JQuery() selector
+   *
+   * @var string
+   */
+  protected $selector;
+
+  /**
+   * Constructs an AlertCommand object.
+   *
+   * @param string $text
+   *   The text to be displayed in the alert box.
+   */
+  public function __construct($selector, $hotspotid, $sceneid) {
+    $this->selector = $selector;
+    $this->hotspotid = $hotspotid;
+    $this->sceneid = $sceneid;
+
+  }
+
+  /**
+   * Implements Drupal\Core\Ajax\CommandInterface:render().
+   */
+  public function render() {
+
+    return [
+      'command' => 'webform_strawberryfield_pannellum_editor_removeHotSpot',
+      'selector' => $this->selector,
+      'hotspotid' => $this->hotspotid,
+      'sceneid' => $this->sceneid,
+    ];
+  }
+
+}
+

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -951,15 +951,10 @@ class WebformPanoramaTour extends WebformCompositeBase {
 
     $element_name = $element['#name'];
 
-
-    error_log(print_r($element_name,true));
-
     dpm($form_state->getValues());
 
 
     $allscenes = !empty($form_state->getValue([$element_name,'allscenes'])) ? json_decode($form_state->getValue([$element_name,'allscenes']),TRUE) : [];
-    error_log(var_export($allscenes,true));
-
 
     if ($form_state->getValue([$element_name, 'currentscene'])
       && $allscenes) {
@@ -982,14 +977,21 @@ class WebformPanoramaTour extends WebformCompositeBase {
           error_log('printing hotspots to delete');
           foreach($existing_objects as $key => $hotspot) {
             error_log(print_r($hotspot,true));
+            if (is_array($hotspot)) {
+              $hotspot = (object) $hotspot;
+            }
             if ($hotspot->id == $button['#hotspottodelete']) {
               $keytodelete = $key;
+              break;
             }
           }
-          if (isset($keytodelete)) {
-            unset($existing_objects[$button['#hotspottodelete']]);
+          // Because 0 will not pass an isset so ....
+          if ($keytodelete !== NULL) {
+            unset($existing_objects[$keytodelete]);
             $existing_objects = array_values($existing_objects);
             $allscenes[$scene_key]['hotspots'] = $existing_objects;
+            error_log('all scenes after hotspot deletion');
+            error_log(print_r($allscenes,true));
           }
         }
       }
@@ -1017,7 +1019,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
     array $form,
     FormStateInterface $form_state
   ) {
-    error_log('calling deleteHotSpotCallback');
+    error_log('calling deleteHotSpotCallback via ajax');
     $button = $form_state->getTriggeringElement();
 
     error_log(print_r($button['#array_parents'],true));
@@ -1057,7 +1059,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
 
 
   /**
-   * Submit Handler for Settin the Scene Orientation.
+   * Submit Handler for Setting the Scene Orientation.
    *
    * @param array $form
    * @param \Drupal\Core\Form\FormStateInterface $form_state
@@ -1095,8 +1097,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
       $form_state->set($all_scenes_key, $allscenes);
       $form_state->setValue([$element_name, 'allscenes'],json_encode($allscenes));
     }
-
-
 
     // This is strange but needed.
     // If we are creating a new  panorama, addhotspot submit button

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -981,7 +981,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
         if (isset($button['#hotspottodelete'])) {
           error_log('printing hotspots to delete');
           foreach($existing_objects as $key => $hotspot) {
-            error_log(print_r($hotspot),true);
+            error_log(print_r($hotspot,true));
             if ($hotspot->id == $button['#hotspottodelete']) {
               $keytodelete = $key;
             }
@@ -1034,39 +1034,24 @@ class WebformPanoramaTour extends WebformCompositeBase {
     $existing_objects = [];
     $current_scene = $form_state->getValue([$element_name, 'currentscene']);
     error_log($current_scene);
-    if ($current_scene) {
-      $allscenes = $form_state->getValue([$element_name, 'allscenes']);
-
-      $allscenes = json_decode($allscenes, TRUE);
-      $current_scene = $form_state->getValue([$element_name, 'scene']);
-      $scene_key = 0;
-      $existing_objects = [];
-      foreach ($allscenes as $key => &$scene) {
-        if ($scene['scene'] == $current_scene
-        ) {
-          $scene_key = $key;
-          $existing_objects = $scene['hotspots'];
-        }
-      }
-    }
-    if (count($existing_objects) > 0) {
+    if (isset($button['#hotspottodelete'])) {
 
       $data_selector2 = $element['hotspots_temp']['#attributes']['data-drupal-selector'];
 
       $response->addCommand(
         new removeHotSpotCommand(
           '[data-drupal-selector="' . $data_selector2 . '"]',
-          end($existing_objects),
+          $button['#hotspottodelete'],
           'webform_strawberryfield_pannellum_editor_addHotSpot'
         )
       );
     }
-    $response->addCommand(
+   /* $response->addCommand(
       new ReplaceCommand(
         '[data-drupal-loaded-node-hotspot-table="' . $data_selector . '"]',
         $element['hotspots_temp']['added_hotspots']
       )
-    );
+    );*/
     return $response;
   }
 

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -939,7 +939,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
    *
    * Adds Key and View Mode to the Table Drag  Table.
    */
-  public function deleteHotSpot(array &$form, FormStateInterface $form_state) {
+  public static function deleteHotSpot(array &$form, FormStateInterface $form_state) {
 
     error_log('calling deleteHotSpot\n\r');
     $button = $form_state->getTriggeringElement();
@@ -963,6 +963,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
 
     if ($form_state->getValue([$element_name, 'currentscene'])
       && $allscenes) {
+      $all_scenes_key = $element_name . '-allscenes';
       $current_scene = $form_state->getValue([$element_name, 'currentscene']);
       $scene_key = 0;
       $existing_objects = [];
@@ -978,7 +979,9 @@ class WebformPanoramaTour extends WebformCompositeBase {
       error_log(print_r($existing_objects, true));
       if ($existing_objects && is_array($existing_objects)) {
         if (isset($button['#hotspottodelete'])) {
+          error_log('printing hotspots to delete');
           foreach($existing_objects as $key => $hotspot) {
+            error_log(print_r($hotspot),true);
             if ($hotspot->id == $button['#hotspottodelete']) {
               $keytodelete = $key;
             }
@@ -1033,6 +1036,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
     error_log($current_scene);
     if ($current_scene) {
       $allscenes = $form_state->getValue([$element_name, 'allscenes']);
+
       $allscenes = json_decode($allscenes, TRUE);
       $current_scene = $form_state->getValue([$element_name, 'scene']);
       $scene_key = 0;

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -8,7 +8,6 @@ use Drupal\webform\Element\WebformCompositeBase;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
-use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Ajax\SettingsCommand;
 use Drupal\webform_strawberryfield\Ajax\AddHotSpotCommand;
 use Drupal\webform_strawberryfield\Ajax\RemoveHotSpotCommand;
@@ -250,8 +249,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
           foreach ($all_scene_nodes as $entity) {
             $options[$entity->id()] = $entity->label();
           }
-          error_log('current node id');
-          error_log(print_r($node->id(), true));
+
           $element['currentscene']['#weight'] = 2;
           $element['currentscene'] =  [
           '#title' => t('Editing Scene'),
@@ -264,11 +262,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
             ],
           '#submit' => [[get_called_class(), 'changeSceneSubmit']],
           ];
-          /*// Hide the select button, at least visually
-          // because it defines the main submit
-          $element['select_button'] = [
-           '#attributes' => ['class' => ['js-hide']]
-          ];*/
         }
 
         $nodeview = $vb->view($node);
@@ -355,7 +348,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
         ];
         $optionscenes = is_array($options) ? $options : [];
         // Remove from linkable scenes the current loaded one
-        // unset($optionscenes[$nodeid]);
 
         $element['hotspots_temp']['adoscene'] = [
           '#title' => t('Linkable Scenes'),
@@ -372,9 +364,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
             'data-drupal-hotspot-property' => 'type',
           ],
         ];
-        // Instead of // unset($optionscenes[$nodeid]); because  \Drupal\Core\Form\FormValidator::performRequiredValidation
-        // Will throw a an error if we remove an option that was just submitted for a select
-        // And we really need in this form that all is validated so values are passed around.
 
         $element['hotspots_temp']['adoscene'][$nodeid] = ['#disabled' => TRUE];
 
@@ -474,12 +463,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
             if (is_array($hotspot)) {
               $hotspot = (object) $hotspot;
             }
-            // Key will be in element['#name'].'_'.count($hotspot_list)+1;
 
-
-            //#pre render the button. Tables do not allow
-            // AJAX/Form functionality
-            // So we have to force this
             $delete_hot_spot_button = [
               '#hotspottodelete' => $hotspot->id,
               '#type' => 'submit',
@@ -688,8 +672,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
       $form,
       array_slice($button['#array_parents'], 0, -2)
     );
-    error_log('selectSceneCallBack');
-    error_log($element['#name']);
     $response = new AjaxResponse();
     $data_selector = $element['#attributes']['data-drupal-selector'];
     $response->addCommand(
@@ -947,7 +929,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
    */
   public static function deleteHotSpot(array &$form, FormStateInterface $form_state) {
 
-    error_log('calling deleteHotSpot\n\r');
     $button = $form_state->getTriggeringElement();
 
     $element = NestedArray::getValue(
@@ -974,13 +955,9 @@ class WebformPanoramaTour extends WebformCompositeBase {
         }
       }
       $keytodelete = NULL;
-      error_log(print_r($existing_objects, true));
       if ($existing_objects && is_array($existing_objects)) {
         if (isset($button['#hotspottodelete'])) {
-          error_log('printing hotspots to delete with id:');
-          error_log($button['#hotspottodelete']);
           foreach($existing_objects as $key => $hotspot) {
-            error_log(print_r($hotspot,true));
             if (is_array($hotspot)) {
               $hotspot = (object) $hotspot;
             }
@@ -994,8 +971,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
             unset($existing_objects[$keytodelete]);
             $existing_objects = array_values($existing_objects);
             $allscenes[$scene_key]['hotspots'] = $existing_objects;
-            error_log('all scenes after hotspot deletion');
-            error_log(print_r($allscenes,true));
           }
         }
       }
@@ -1023,24 +998,17 @@ class WebformPanoramaTour extends WebformCompositeBase {
     array $form,
     FormStateInterface $form_state
   ) {
-    error_log('calling deleteHotSpotCallback via ajax');
     $button = $form_state->getTriggeringElement();
-    error_log(print_r($form_state->getValues(), true));
-    error_log(print_r($button, true));
-    error_log(print_r($button['#array_parents'],true));
-    error_log(print_r(array_slice($button['#array_parents'], 0, -4),true ));
     $element = NestedArray::getValue(
       $form,
       array_slice($button['#array_parents'], 0, -4)
     );
 
     $element_name = $element['#name'];
-    error_log($element_name);
     $response = new AjaxResponse();
     $data_selector = $element['hotspots_temp']['added_hotspots']['#attributes']['data-drupal-loaded-node-hotspot-table'];
     $existing_objects = [];
     $current_scene = $form_state->getValue([$element_name, 'currentscene']);
-    error_log($current_scene);
     if (isset($button['#hotspottodelete'])) {
 
       $data_selector2 = $element['hotspots_temp']['#attributes']['data-drupal-selector'];
@@ -1128,7 +1096,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
       $form,
       array_slice($button['#array_parents'], 0, -2)
     );
-    error_log('setSceneOrientationCallBack');
     $response = new AjaxResponse();
     $element_name = $element['#name'];
     $data_selector = $element['hotspots_temp']['#attributes']['data-webform_strawberryfield-selector'];
@@ -1155,7 +1122,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
     FormStateInterface $form_state
   ) {
 
-    error_log('deleteScene');
     $button = $form_state->getTriggeringElement();
     $hot_spot_values_parents = array_slice($button['#parents'], 0, -1);
 
@@ -1195,7 +1161,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
       }
 
       \Drupal::messenger()->addMessage(t('The Scene was removed'));
-      error_log('done removing Scene and hotspots');
     }
     // This is strange but needed.
     // If we are creating a new  panorama, addhotspot submit button
@@ -1222,7 +1187,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
       $form,
       array_slice($button['#array_parents'], 0, -2)
     );
-    error_log('deleteSceneCallBack');
     $response = new AjaxResponse();
     $element_name = $element['#name'];
     $data_selector = $element['#attributes']['data-drupal-selector'];
@@ -1259,8 +1223,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
           ],
         ]
       ];
-      error_log('attaching replacement Drupal settings for the viewer after delete');
-      error_log(print_r($settings, TRUE));
+
       // Why twice? well because merge is deep merge. Gosh JS!
       // And merge = FALSE clears even my brain settings...
       $response->addCommand(new SettingsCommand($settings, TRUE));

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -490,8 +490,8 @@ class WebformPanoramaTour extends WebformCompositeBase {
 
               ],
               '#value' => t('Remove'),
-              '#id' => $element['#name'].'-remove-hotspot-'.$key,
-              '#name' => $element['#name'].'-remove-hotspot-'.$key,
+              '#id' => $element['#name'].'-remove-hotspot-'.$hotspot->id,
+              '#name' => $element['#name'].'-remove-hotspot-'.$hotspot->id,
               '#submit' => [[get_called_class(),'deleteHotSpot']],
               '#ajax' => [
                 'callback' => [ get_called_class(), 'deleteHotSpotCallback'],
@@ -512,7 +512,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
               'label' =>  [
                 '#type' => 'html_tag',
                 '#tag' => 'p',
-                '#value' => isset($hotspot->text) ? $hotspot->text : t('no name'),
+                '#value' => isset($hotspot->text) ? $hotspot->text ." ". $hotspot->id." " : t('no name'),
                 ],
               'operations' => $delete_hot_spot_button
               ];
@@ -531,7 +531,13 @@ class WebformPanoramaTour extends WebformCompositeBase {
               'data-drupal-loaded-node-hotspot-table' => $nodeid
             ],
           ];
-          $element['hotspots_temp']['added_hotspots'] = array_merge($element['hotspots_temp']['added_hotspots'], $table_options);
+          if (count($table_options)) {
+            // Don't add rows if no Hotspots.
+            $element['hotspots_temp']['added_hotspots'] = array_merge(
+              $element['hotspots_temp']['added_hotspots'],
+              $table_options
+            );
+          }
 
         }
       }
@@ -951,9 +957,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
 
     $element_name = $element['#name'];
 
-    dpm($form_state->getValues());
-
-
     $allscenes = !empty($form_state->getValue([$element_name,'allscenes'])) ? json_decode($form_state->getValue([$element_name,'allscenes']),TRUE) : [];
 
     if ($form_state->getValue([$element_name, 'currentscene'])
@@ -974,7 +977,8 @@ class WebformPanoramaTour extends WebformCompositeBase {
       error_log(print_r($existing_objects, true));
       if ($existing_objects && is_array($existing_objects)) {
         if (isset($button['#hotspottodelete'])) {
-          error_log('printing hotspots to delete');
+          error_log('printing hotspots to delete with id:');
+          error_log($button['#hotspottodelete']);
           foreach($existing_objects as $key => $hotspot) {
             error_log(print_r($hotspot,true));
             if (is_array($hotspot)) {
@@ -1021,7 +1025,8 @@ class WebformPanoramaTour extends WebformCompositeBase {
   ) {
     error_log('calling deleteHotSpotCallback via ajax');
     $button = $form_state->getTriggeringElement();
-
+    error_log(print_r($form_state->getValues(), true));
+    error_log(print_r($button, true));
     error_log(print_r($button['#array_parents'],true));
     error_log(print_r(array_slice($button['#array_parents'], 0, -4),true ));
     $element = NestedArray::getValue(
@@ -1048,12 +1053,12 @@ class WebformPanoramaTour extends WebformCompositeBase {
         )
       );
     }
-   /* $response->addCommand(
+   $response->addCommand(
       new ReplaceCommand(
         '[data-drupal-loaded-node-hotspot-table="' . $data_selector . '"]',
         $element['hotspots_temp']['added_hotspots']
       )
-    );*/
+    );
     return $response;
   }
 


### PR DESCRIPTION
See #39 

# First pass:

## This fixes:
 - Issue with Hotspots being re-validated when changing currently being edited Panorama Scene. Changed "select" element for a "radios" one, so i can disable the current Scene when allowing inter-scene hotspots to be added. If not Drupal fails on validating the form because the selected options change and it feels someone is tampering with the form.
- Uses Input and Form State Value setting when adding a new scene. That way currently selected scene (select box) changes also when adding a new scene
- Fixes "Set Current Scene orientation". Need to test this further.

Will keep adding commits to this pull until ready for merging.