### PR TITLE
ISSUE-41a: Make temporary Storage used for Webform persistence stronger

### DIFF
--- a/js/cameraroll-webform_strawberryfield.js
+++ b/js/cameraroll-webform_strawberryfield.js
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * Adds an capture camera to inputs
+ */
+
+(function ($, Drupal, drupalSettings) {
+
+    'use strict';
+
+    /**
+     * Attaches our custom show/hide node actions button
+     *
+     * @type {Drupal~behavior}
+     *
+     * @prop {Drupal~behaviorAttach} attach
+     *   Attaches the autocomplete behaviors.
+     */
+    Drupal.behaviors.webformstrawberryCameraRoll = {
+        attach: function (context, settings) {
+            console.log('hey!');
+            // Only react if the document contains a strawberry webform widget
+            if ($('.path-node fieldset[data-strawberryfield-selector="strawberry-webform-widget"]').length) {
+                $('input[type="file"].form-file').each(function(idx, item) {
+                    console.log($(item).attr('accept'));
+                    if ($(item).attr('accept') == 'image/*') {
+                        $(item).attr('accept', 'image/*;capture=camera');
+                    }
+                });
+            }
+        }
+    }
+})(jQuery, Drupal, drupalSettings);

--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -25,15 +25,13 @@
                 } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
                     $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
                 }
-
-
                 var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
                 if ($moderationstate.length) {
 
-                    var $select = $moderationstate.on('change', function () {
+                    /* var $select = $moderationstate.on('change', function () {
                         $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
 
-                    });
+                    }); */
                 }
                 var $nodetitle = $('input[data-drupal-selector="edit-title-0-value"]', context).once('show-hide-actions');
                 if ($nodetitle.length) {

--- a/src/Element/WebformWithOverride.php
+++ b/src/Element/WebformWithOverride.php
@@ -44,7 +44,6 @@ class WebformWithOverride extends Webform {
     if (!$webform) {
       return $element;
     }
-
     if ($webform->access('submission_create')) {
       $values = [];
 
@@ -73,7 +72,8 @@ class WebformWithOverride extends Webform {
       // Where we can get rid of the internal 'form' rendering
       // Allowing DOM to set the so needed classes for the wrapper
       // So states and other WEbform AJAX libraries can work correctly.
-      // We don't want a full blown preprocess (yet).
+      // @TODO we will need a full blown preprocess since this is not being set
+      // If the form fails to validate in some step.
       $element['webform_build']['#attributes']['data-webform-inline-fieldwidget'] = 'true';
 
       // Set custom form action.
@@ -92,7 +92,6 @@ class WebformWithOverride extends Webform {
       $renderer->addCacheableDependency($element, $config);
       $renderer->addCacheableDependency($element, $webform);
     }
-
     return $element;
   }
 

--- a/src/EventSubscriber/WebformStrawberryfieldDeleteTmpStorage.php
+++ b/src/EventSubscriber/WebformStrawberryfieldDeleteTmpStorage.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\webform_strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+
+/**
+ * Event subscriber that deletes Webform temp storage for SBF bearing entities.
+ *
+ * The actual deletion only happens after persistance of a Node.
+ *
+ */
+class WebformStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The serializer.
+   * @var \Symfony\Component\Serializer\SerializerInterface;
+   */
+  protected $serializer;
+
+  /**
+   * Stores the tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * StrawberryfieldEventInsertSubscriberDepositDO constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory,
+    PrivateTempStoreFactory $temp_store_factory
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+    $this->tempStoreFactory = $temp_store_factory;
+
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::SAVE][] = ['onEntitySave', static::$priority];
+    $events[StrawberryfieldEventType::INSERT][] = ['onEntityINSERT', static::$priority];
+    return $events;
+  }
+
+
+
+
+  /**
+   * Method called when Event occurs.
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function onEntityInsert(StrawberryfieldCrudEvent $event) {
+    /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+
+    // Means a new Entity
+    // Our storage key will be quite generic named
+
+    $current_class = get_called_class();
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+
+    /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
+    $tempstore =  $this->tempStoreFactory->get('archipel');
+
+    foreach ($sbf_fields as $field_name) {
+
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+
+      $field = $entity->get($field_name);
+
+      $fieldname = $field->getName();
+      foreach ($field->getValue() as $delta => $value) {
+        $keyid = $this->getTempStoreKeyName($fieldname, $delta, '');
+        $tempstore->delete($keyid);
+      }
+    }
+
+    $event->setProcessedBy($current_class, true);
+  }
+
+
+  /**
+   * Method called when Save/Update Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Core\TempStore\TempStoreException
+   */
+  public function onEntitySave(StrawberryfieldCrudEvent $event) {
+    /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+
+    // Means an existing Entity
+    // Our storage key will be less generic, using the actual uuid.
+
+    $current_class = get_called_class();
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+
+    /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
+    $tempstore =  $this->tempStoreFactory->get('archipel');
+
+    foreach ($sbf_fields as $field_name) {
+
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      $field = $entity->get($field_name);
+
+      $fieldname = $field->getName();
+      foreach ($field->getValue() as $delta => $value) {
+        $keyid = $this->getTempStoreKeyName($fieldname, $delta, $entity->uuid());
+        $tempstore->delete($keyid);
+      }
+    }
+
+    $event->setProcessedBy($current_class, true);
+  }
+
+  /**
+   * Gives us a key name used by the webforms and widgets.
+   *
+   * @param $fieldname
+   * @param int $delta
+   * @param string $entity_uuid
+   *
+   * @return string
+   */
+  public function getTempStoreKeyName($fieldname, $delta = 0, $entity_uuid = '0') {
+    $unique_seed = array_merge(
+      [$fieldname],
+      [$delta],
+      [$entity_uuid]
+    );
+    return sha1(implode('-', $unique_seed));
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
@@ -136,6 +136,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     // Where is this field being used, a node?
     $entity_type = $items->getEntity()->getEntityTypeId();
     $bundle = $items->getEntity()->bundle();
+    $bundle_label = $items->getEntity()->type->entity->label();
     // So does the current loaded entity, where this widget is shown
     // has an id? If it has means we are editing!
     // We can always check via $items->getEntity()->isNew()
@@ -164,6 +165,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
       $entity_uuid = $items->getEntity()->uuid();
       $entity_id = $items->getEntity()->id();
     }
+    $form_state->set('strawberryfield_webform_bundle_label', $bundle_label);
 
     // We will identify this widget amongst others using its form parents
     // as sha1 seed we use something unique what will stay the same across
@@ -254,6 +256,27 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     );
 
     $savedvalue = $items[$delta]->getValue();
+    $tempstore = \Drupal::service('tempstore.private')->get('archipel');
+    $tempstoreId = $this_widget_id;
+
+    /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
+    // Which means an abandoned Metadata Sessions somewhere
+    // Someone saved 'metadata' during a form update and left for coffee
+    // WE can reuse!
+    if (($tempstore->getMetadata($tempstoreId) != NULL) && $items->getEntity()->isNew()) {
+      $json_string = $tempstore->get($tempstoreId);
+      $json = json_decode($json_string, TRUE);
+      $json_error = json_last_error();
+      if ($json_error == JSON_ERROR_NONE) {
+        $savedvalue['value'] = $json_string;
+      }
+      $element['strawberry_webform_inline_message'] = [
+          '#type' => 'item',
+          '#title' => $this
+            ->t('Resuming metadata session:'),
+          '#markup' =>  $this->t('We found and loaded a previous unfinished metadata session for you.')
+      ];
+    }
 
     // Autofill from a previus submision if current value is empty
     $webform_autofill = empty($savedvalue['value']) || $items->getEntity()->isNew();
@@ -370,16 +393,29 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
 
   public function validateWebform($element, FormStateInterface $form_state) {
     // Validate
-    // We have two states really:
-    // If old/loaded value is not empty then
+
     $tempstoreId = $form_state->get('strawberryfield_webform_widget_id');
     /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
 
     $tempstore = \Drupal::service('tempstore.private')->get('archipel');
-    if ($tempstore->getMetadata($tempstoreId) == NULL) {
-        // Means its empty. This can be Ok if something else than "save"
-        // Is triggering the Ajax Submit action like the "Display Switch"
-        // @TODO investigate some #limit_validation_error options to avoid that
+    if ($tempstore->getMetadata($tempstoreId) == NULL ) {
+      // Means its empty. This can be Ok if something else than "save"
+      // Is triggering the Ajax Submit action like the "Display Switch"
+      // Or we are not enforcing (required) really any values
+      if ($form_state->get('strawberryfield_webform_isnew')) {
+        // But if this a new Object and the tempstore is empty means
+        // No filling, no doing anything has happened
+        // And that is bad. So mark an error
+        $form_state->setError(
+          $element,
+          $this->t(
+            "Please complete all steps. You can not Save this @bundle_label without completing the required Form.",
+            [
+              '@bundle_label' => $form_state->get('strawberryfield_webform_bundle_label')
+            ]
+          )
+        );
+      }
         return;
     }
 
@@ -388,7 +424,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     $json_error = json_last_error();
     if ($json_error == JSON_ERROR_NONE) {
       $form_state->setValueForElement($element['strawberry_webform_widget']['json'], $json_string);
-      // Let tempstore entry expire, don't remove manually.
+      // Let tempstore entry expire or be removed by \Drupal\webform_strawberryfield\EventSubscriber\WebformStrawberryfieldDeleteTmpStorage
       return;
     }
     else {

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
@@ -340,16 +340,14 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
   }
 
   public function validateWebform($element, FormStateInterface $form_state) {
-    // Validate
-    // We have two states really:
-    // If old/loaded value is not empty then
+
     $tempstoreId = $form_state->get('strawberryfield_webform_widget_id');
     /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
     $tempstore = \Drupal::service('tempstore.private')->get('archipel');
     if ($tempstore->getMetadata($tempstoreId) == NULL) {
       // Means its empty. This can be Ok if something else than "save"
       // Is triggering the Ajax Submit action like the "Display Switch"
-      // @TODO investigate some #limit_validation_error options to avoid that
+      // Or we are not enforcing (required) really any values
       return;
     }
 

--- a/webform_strawberryfield.libraries.yml
+++ b/webform_strawberryfield.libraries.yml
@@ -5,7 +5,15 @@ webform_strawberryfield.metadataauth.autocomplete:
     - core/drupal.autocomplete
 webform_strawberryfield.nodeactions.toggle:
   js:
-    js/hidenodeaction-webform_strawberryfield.js: {}
+    js/hidenodeaction-webform_strawberryfield.js: {minified: false}
+  dependencies:
+    - core/jquerywebform_strawberryfield.nodeactions.toggle
+    - core/drupal
+    - core/drupalSettings
+    - core/drupal.form
+webform_strawberryfield.nodeactions.cameraroll:
+  js:
+    js/cameraroll-webform_strawberryfield.js : {minified: false}
   dependencies:
     - core/jquery
     - core/drupal

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -419,10 +419,11 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
           $status
         );
         if ($status != 0) {
-          \Drupal::service('messenger')
+          // This message is annoying. Appears over and over.
+          /*\Drupal::service('messenger')
             ->addMessage(
               t('Ups. We could not get EXIF from your file. Sorry.')
-            );
+            );*/
         }
         else {
           $more_str = implode('', $output);

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -33,6 +33,7 @@ function webform_strawberryfield_form_alter(&$form,FormStateInterface $form_stat
   /** @var \Drupal\webform\WebformSubmissionForm $submission_form */
   $submission_form = $form_state->getFormObject();
   $form['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.nodeactions.toggle';
+  $form['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.nodeactions.cameraroll';
 
   if (strpos($form_id, 'webform_submission') === 0
     && $submission_form instanceof WebformSubmissionForm) {

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -278,6 +278,9 @@ function webform_strawberryfield_theme_suggestions_webform_alter(&$suggestions, 
   // \Drupal\webform_strawberryfield\Element\WebformWithOverride::preRenderWebformElement
   $element = $variables['element'];
   // This is in particular for 'webform_inline_fieldwidget' element
+  // This is not triggering when the form has validation errors
+  // WebformWithOverride::preRenderWebformElement is not able to set the attribute
+  // Probably we need a better way
   if (isset($element['#attributes']['data-webform-inline-fieldwidget'])) {
     $suggestions = ['webform_inline_fieldwidget_form', 'webform_inline_fieldwidget_form__' . $element['#webform_id']];
   }
@@ -300,7 +303,6 @@ function webform_strawberryfield_theme_suggestions_webform_alter(&$suggestions, 
 function webform_strawberryfield_preprocess_webform_element_image_file(
   array &$variables
 ) {
-
   if (!empty($variables['file'])) {
     // TODO do we need a setting for this?
     $max_width = 320;
@@ -531,5 +533,3 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
 
   }
 }
-
-

--- a/webform_strawberryfield.services.yml
+++ b/webform_strawberryfield.services.yml
@@ -1,0 +1,6 @@
+services:
+  webform_strawberryfield.deletetmpstorage_subscriber:
+    class: Drupal\webform_strawberryfield\EventSubscriber\WebformStrawberryfieldDeleteTmpStorage
+    tags:
+      - {name: event_subscriber}
+    arguments: ['@string_translation', '@messenger', '@logger.factory', '@tempstore.private']


### PR DESCRIPTION
See #41 

This is a WIP for making the temporary storage for Webform widget/Node interaction better.

This brings a few changes and improvements
- Removes the dystopian and silly idea of hiding/showing via AJAX de node save button on Node State change. That confuses people a lot
- Adds a Temporary Storage deleter Subscriber that triggers when and only when we are sure the Node is save and sleeping in his bed and dreaming with clouds of candy
- Adds a Loader for temporary storage if it was persisted but the node was not saved.This allows broken sessions to be retaken (love this)
- For Object Edits, instead of showing the expanded Webform, it brings back the 'Edit metadata' button. This allows edits to a node, like changing state to happen without having to go into edit mode


TODOS: 
- we should have a full preprocessor for the webform with override element.
- Add a 'Cancel edit' when in webform/metadata edit mode: node. All this was solved 2 years ago when i had the popup overlay. I wish i had convinced people 2 years ago that an overlay was the right way. All was so simple.
- Make sure the not-inline widget works the same way