### PR TITLE
Issue 47: JP2 and MP4 support for Upload fields and WIKIDATA elements without visible URL

### DIFF
--- a/js/cameraroll-webform_strawberryfield.js
+++ b/js/cameraroll-webform_strawberryfield.js
@@ -8,7 +8,7 @@
     'use strict';
 
     /**
-     * Attaches our custom show/hide node actions button
+     * Attaches our custom camera roll enabler for IOS and Android devices
      *
      * @type {Drupal~behavior}
      *

--- a/js/cameraroll-webform_strawberryfield.js
+++ b/js/cameraroll-webform_strawberryfield.js
@@ -17,13 +17,19 @@
      */
     Drupal.behaviors.webformstrawberryCameraRoll = {
         attach: function (context, settings) {
-            console.log('hey!');
             // Only react if the document contains a strawberry webform widget
             if ($('.path-node fieldset[data-strawberryfield-selector="strawberry-webform-widget"]').length) {
                 $('input[type="file"].form-file').each(function(idx, item) {
                     console.log($(item).attr('accept'));
                     if ($(item).attr('accept') == 'image/*') {
-                        $(item).attr('accept', 'image/*;capture=camera');
+                        // We will add by default jp2. If the element is configured to not support it, that is Ok
+                        // Element validation handler will just complain and be will be safe.
+                        $(item).attr('accept', 'image/*;capture=camera;image/jp2');
+                    }
+                    else if ($(item).attr('accept') == 'video/*') {
+                        // We will add by default mp4. If the element is configured to not support it, that is Ok
+                        // Element validation handler will just complain and be will be safe.
+                        $(item).attr('accept', 'video/*;capture=camera;video/mp4');
                     }
                 });
             }

--- a/js/metadataauth-webform_strawberryfield.js
+++ b/js/metadataauth-webform_strawberryfield.js
@@ -78,6 +78,7 @@
                         return;
                     }
                     var $element = uiAutocomplete.menu.element;
+
                     $element.addClass('strawberry-autocomplete-auth');
                     var elementSettings = autocomplete.getSettings(this, settings);
                     if (elementSettings['delay']) {
@@ -95,10 +96,10 @@
                             console.log('Additional Description is :' + ui.item.desc);
                             ui.item.label = ui.item.label.substring(0, ui.item.label.indexOf(ui.item.desc));
                         }
-                        var tempvalue = ui.item.value;
-                        ui.item.value = ui.item.label;
-                        ui.item.label = tempvalue;
-
+                        var tempvalue = ui.item.value.trim();
+                        ui.item.value = ui.item.label.trim();
+                        ui.item.label = tempvalue.trim();
+                        console.log(tempvalue);
                         //$(event.target).parent('.form-type-textfield').next('div.form-type-url').children('input[data-strawberry-autocomplete-value]').val(ui.item.label);
                         var targetname = $(event.target).attr('name');
                         // Where to put the value
@@ -110,9 +111,25 @@
                         var stripped = targetname.substring(0, targetname.indexOf('['+targetsource+']'));
 
                         targetname = stripped + '['+targetdest+']';
+                        var targetname_hidden = stripped + '[_hidden_]['+targetdest+']';
                         console.log(targetname);
-                        $("input[name='"+ targetname +"']").val(ui.item.label);
+                        console.log(targetname_hidden);
+                        if ($("input[name='"+ targetname +"']").length > 0) {
+                            $("input[name='" + targetname + "']").val(ui.item.label);
+                        }
+                        else if($("input[name='"+ targetname_hidden +"']").length > 0)  {
+                            // This acts on a hidden URL when multiple composites are in a table
+                            console.log('URL element is hidden but we got it!');
+                            $("input[name='" + targetname_hidden + "']").val(ui.item.label);
 
+                        }
+                        else {
+                            console.log('URL form sub element does not exist. No URL will be persisted');
+                            // @TODO in this case we could ajax submit and resolve via a submit handler?
+                            //this.closest("form").submit();
+                            //submit form.
+                        }
+                        // Executes pre-existing select handler
                         var ret = oldSelect.apply(this, arguments);
                         return ret;
                     };

--- a/src/Controller/StrawberryRunnerModalController.php
+++ b/src/Controller/StrawberryRunnerModalController.php
@@ -162,14 +162,27 @@ class StrawberryRunnerModalController extends ControllerBase
         // See workaround at \Drupal\webform_strawberryfield\Plugin\WebformHandler\strawberryFieldharvester::preprocessConfirmation
         $new_settings = [
             'confirmation_type' => WebformInterface::CONFIRMATION_INLINE,
-            'confirmation_back' => FALSE,
+            'confirmation_back' => TRUE,
             'results_disabled' => TRUE,
             'autofill' => FALSE,
-            'confirmation_message' => $this->t('Thanks, you are all set! Please Save the content to persist the changes.')
+            'ajax' => TRUE,
+            'form_submit_once' => FALSE,
+            'confirmation_exclude_token' => TRUE,
+            'wizard_progress_link' => TRUE,
+            'submission_user_duplicate' => TRUE,
+            'confirmation_message' => $this->t(
+            'Thanks, you are all set! Please Save the content to persist the changes.')
         ];
 
-        // @todo make autofill v/s none a user setting.
 
+        // @todo make autofill v/s none a user setting.
+        // Override in a way that the handler can actually act on
+        // @See https://www.drupal.org/project/webform/issues/3088386
+        // and where we do this
+        // \Drupal\webform_strawberryfield\Plugin\WebformHandler\strawberryFieldharvester::overrideSettings
+        $data['strawberryfield:override'] = $new_settings;
+
+        // This really does not work on 5.x but could eventually on 6.x
         $webform->setSettingsOverride($new_settings);
 
         $lawebforma = $webform->getSubmissionForm($data);

--- a/src/Element/WebformWikiData.php
+++ b/src/Element/WebformWikiData.php
@@ -32,20 +32,17 @@ class WebformWikiData extends WebformCompositeBase {
     $elements['label'] = [
       '#type' => 'textfield',
       '#title' => t('Label'),
-      //'#title_display' => 'invisible',
       '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
       '#autocomplete_route_parameters' => array('auth_type' => 'wikidata', 'count' => 10),
       '#attributes' => [
         'data-source-strawberry-autocomplete-key' => 'label',
         'data-target-strawberry-autocomplete-key' => 'uri'
       ],
-
-
     ];
+
     $elements['uri'] = [
       '#type' => 'url',
       '#title' => t('Subject URL'),
-      //'#title_display' => 'invisible',
       '#attributes' => ['data-strawberry-autocomplete-value' => TRUE]
     ];
     $elements['label']['#process'][] =  [$class, 'processAutocomplete'];
@@ -57,6 +54,22 @@ class WebformWikiData extends WebformCompositeBase {
    */
   public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
+    $composite_elements = static::getCompositeElements($element);
+    // URL should always end in the HTML to Ajax can autofill the URI coming from
+    // LoD provider.
+    // #access = false is really just converting the elements to hidden elements.
+    // @warning Sadly \Drupal\webform_strawberryfield\Element\WebformWikiData::processWebformComposite is never called
+    // if the multiple__header is enabled.
+    // To get around that we call \Drupal\webform_strawberryfield\Plugin\WebformElement\WebformWikiData::hiddenElementAfterBuild
+    foreach ($composite_elements as $composite_key => $composite_element) {
+      if ($composite_key != 'value') {
+        if (isset($element[$composite_key]['#access']) && $element[$composite_key]['#access'] === FALSE) {
+          unset($element[$composite_key]['#access']);
+          unset($element[$composite_key]['#pre_render']);
+          $element[$composite_key]['#type'] = 'hidden';
+        }
+      }
+    }
     return $element;
   }
 
@@ -78,5 +91,7 @@ class WebformWikiData extends WebformCompositeBase {
     $element['#attributes']['data-strawberry-autocomplete'] = 'wikidata';
     return $element;
   }
+
+
 
 }

--- a/src/Plugin/WebformElement/WebformWikiData.php
+++ b/src/Plugin/WebformElement/WebformWikiData.php
@@ -8,11 +8,12 @@
 
 namespace Drupal\webform_strawberryfield\Plugin\WebformElement;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 
 /**
- * Provides an 'LoC Subject Heading' element.
+ * Provides an 'Wikidata Items' element.
  *
  * @WebformElement(
  *   id = "webform_metadata_wikidata",
@@ -56,5 +57,36 @@ class WebformWikiData extends WebformCompositeBase {
     }
     return $lines;
   }
+
+  /**
+   * @param array $element
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *
+   * @return array
+   */
+  public static function hiddenElementAfterBuild(
+    array $element,
+    FormStateInterface $form_state
+  ) {
+    // We override this method only to convert non accsible elements
+    // Into hidden ones, in case Multiples are being show as tables
+    // Because initialization in that case happens does not happen in
+    // \Drupal\webform_strawberryfield\Element\WebformWikiData::processWebformComposite
+
+    $element = parent::hiddenElementAfterBuild(
+      $element,
+      $form_state
+    );
+    if (isset($element['#element'])) {
+      foreach ($element['#element'] as $subelement_key => &$subelement) {
+        if (isset($subelement['#access']) && !$subelement['#access']) {
+          $subelement['#type'] = 'hidden';
+          $subelement['#access'] = TRUE;
+        }
+      }
+    }
+    return $element;
+  }
+
 
 }

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -417,7 +417,7 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
       }
       if ($templocation) {
         $result = exec(
-          'exiftool -json -q ' . escapeshellcmd($templocation),
+          'exiftool -json -q -a -gps:all -Common "-gps*" -xmp:all  -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellcmd($templocation),
           $output,
           $status
         );


### PR DESCRIPTION
# What is this:

Given the fact ZOOM calls, COVID, teaching is taking a lot of time, i will try to bring a few ISSUES inside a single Pull.
This one solves #47 and #48 and #49

But also solves something i had been wanting for a long long time: 
- How we override settings for our webforms. This allows now, finally to override settings like 'Always use Ajax' or make sure confirmation message is always inline. 
- Too much visible EXIF data (to be honest i understand the use case, i just don't like showing EXIF people on upload and will eventually fix all of this

@giancarlobi @mitchellkeaney 