### PR TITLE
ISSUE-29: LoC how was your day? LoC, Favorite travel destination? Any personal name that starts with Bee? Bee (Fictitious character from Hart)

### DIFF
--- a/src/Element/WebformLoC.php
+++ b/src/Element/WebformLoC.php
@@ -20,6 +20,11 @@ class WebformLoC extends WebformCompositeBase {
     //@TODO add an extra option to define auth_type.
     //@TODO expose as an select option inside \Drupal\webform_strawberryfield\Plugin\WebformElement\WebformLoC
     $info = parent::getInfo();
+    // Always defaults to subjects
+    $info = $info + [
+      '#vocab' => 'subjects',
+      '#rdftype' => 'FullNameElement',
+    ];
     return $info;
   }
 
@@ -28,13 +33,20 @@ class WebformLoC extends WebformCompositeBase {
    */
   public static function getCompositeElements(array $element) {
     $elements = [];
+    $vocab = 'subjects';
+    $rdftype = 'thing';
+  if (isset($element['#vocab'])) {
+    $vocab = $element['#vocab'];
+  }
+  if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+    $rdftype = trim($element['#rdftype']);
+  }
     $class = '\Drupal\webform_strawberryfield\Element\WebformLoC';
     $elements['label'] = [
       '#type' => 'textfield',
       '#title' => t('Label'),
-      //'#title_display' => 'invisible',
       '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
-      '#autocomplete_route_parameters' => array('auth_type' => 'loc', 'count' => 10),
+      '#autocomplete_route_parameters' => array('auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10),
       '#attributes' => [
         'data-source-strawberry-autocomplete-key' => 'label',
         'data-target-strawberry-autocomplete-key' => 'uri'
@@ -44,7 +56,6 @@ class WebformLoC extends WebformCompositeBase {
     $elements['uri'] = [
       '#type' => 'url',
       '#title' => t('Subject URL'),
-      //'#title_display' => 'invisible',
       '#attributes' => ['data-strawberry-autocomplete-value' => TRUE]
     ];
     $elements['label']['#process'][] =  [$class, 'processAutocomplete'];
@@ -56,6 +67,10 @@ class WebformLoC extends WebformCompositeBase {
    */
   public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
+
+    //dpm('the element');
+    //dpm($element);
+
     return $element;
   }
 
@@ -71,8 +86,8 @@ class WebformLoC extends WebformCompositeBase {
     $element = parent::processAutocomplete($element, $form_state, $complete_form);
     $element['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.metadataauth.autocomplete';
     $element['#attached']['drupalSettings'] = [
-        'webform_strawberryfield_autocomplete' => [],
-      ];
+      'webform_strawberryfield_autocomplete' => [],
+    ];
 
     $element['#attributes']['data-strawberry-autocomplete'] = 'LoC';
     return $element;

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -12,10 +12,13 @@ webform_strawberryfield.close_modal_webform:
   requirements:
     _permission: 'access content'
 webform_strawberryfield.auth_autocomplete:
-  path: '/webform_strawberry/auth_autocomplete/{auth_type}/{count}'
+  path: '/webform_strawberry/auth_autocomplete/{auth_type}/{vocab}/{rdftype}/{count}'
   defaults:
     _controller: '\Drupal\webform_strawberryfield\Controller\AuthAutocompleteController::handleAutocomplete'
     _format: json
+    vocab: subjects
+    count: 1
+    rdftype: thing
   requirements:
     _access: 'TRUE'
 webform_strawberryfield.nominatim:


### PR DESCRIPTION
See #29 

LoC Webform elements gets an update, double ration of wiped cream and a real, fresh, strawberry on top + (see the rdftype option) a milk shake to go.

This pull replaces branch https://github.com/esmero/webform_strawberryfield/tree/ISSUE-29 (old work) to revamp our LoC Suggest endpoints with the new features:
 
- Changes:
LoC Webform Element is not longer a Subject only one autocomplete, but can deal with any LoC Suggest. When setting it up in your Webform, by default you now a vocabulary option (deceiving because some are 'Authorities' and some other 'vocabularies' but the line is blurry, so let's name this 'vocabulary': the options are:
 - 'subjects',
 - 'names',
- 'genreForms',
-  'graphicMaterials',
-  'geographicAreas',
Plus a fake one that triggers a second option  
-  'rdftype',
And that is a filter against any RDF type (see owl:class) from this mads list here http://id.loc.gov/ontologies/madsrdf/v1.html
which gives the admin/metadata aficionado access to fetch from any/all sources and filter by the 'thing' type. Geographic, PersonalName, etc, you name it.

This can be of interest of @alliomeria and @giancarlobi . Will be enabled as testing option in play.archipelago.nyc later tomorrow.
Note: Getty's SPARQL endpoint is down as i write, tweeted some S.O.S but not sure anyone other than me is worried about LoD so late on a Sunday.

Questions: Should i add also FAST (OCLC) autocomplete?
Also. Should i allow an additional SPARQL query autocomplete directly against WIKIDATA to simulate the same idea we have here of LoC, a filter against rdftype?


