### PR TITLE
ISSUE-41: Make sure the entity mapping list ends being an array 

### DIFF
--- a/src/Plugin/WebformHandler/strawberryFieldharvester.php
+++ b/src/Plugin/WebformHandler/strawberryFieldharvester.php
@@ -277,17 +277,17 @@ class strawberryFieldharvester extends WebformHandlerBase {
     // @see https://www.drupal.org/project/webform/issues/3067958
     if (isset($entity_mapping_structure['entity:node'])) {
       //@TODO change this stub. Get every element that extends Drupal\webform\Plugin\WebformElementEntityReferenceInterface()
-      $entity_mapping_structure['entity:node'] = array_unique(
-        $entity_mapping_structure['entity:node'],
+      $entity_mapping_structure['entity:node'] = array_values(
+        array_unique($entity_mapping_structure['entity:node'],
         SORT_STRING
-      );
+      ));
     }
 
     if (isset($entity_mapping_structure['entity:file'])) {
-      $entity_mapping_structure['entity:file'] = array_unique(
-        $entity_mapping_structure['entity:file'],
+      $entity_mapping_structure['entity:file'] = array_values(
+        array_unique($entity_mapping_structure['entity:file'],
         SORT_STRING
-      );
+      ));
     }
     // Distribute all processed AS values for each field into its final JSON
     // Structure, e.g as:image, as:application, as:documents, etc.


### PR DESCRIPTION
# What is this?

Things that happen when you do a lot of coding. Commits get off sync. This one is from ISSUE-41 but did not end getting intop beta3. Fixing that here



Without this commit (sometimes, when source json keys come from multiple non consecutive places. Remember JSON ENCODE and DECODE does not ensure order.

 "ap:entitymapping": {
        "entity:file": {
            "0": "images",
             ....
            "12":  "upload_associated_warc"
        ]
    },

With this!

 "ap:entitymapping": {
        "entity:file": [
            "images",
            "documents",
            "audios",
            "videos",
            "models",
            "vtts",
            "upload_associated_warc"
        ]
    },