### PR TITLE
ISSUE-29c: Fixing multiple LoC Autocomplete elements showing as a single one/ not respecting our wishes

### DIFF
--- a/src/Element/WebformLoC.php
+++ b/src/Element/WebformLoC.php
@@ -17,14 +17,11 @@ class WebformLoC extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public function getInfo() {
-    //@TODO add an extra option to define auth_type.
-    //@TODO expose as an select option inside \Drupal\webform_strawberryfield\Plugin\WebformElement\WebformLoC
-    $info = parent::getInfo();
-    // Always defaults to subjects
-    $info = $info + [
-      '#vocab' => 'subjects',
-      '#rdftype' => 'FullNameElement',
-    ];
+
+    $info =  parent::getInfo() + [
+      '#vocab' => '',
+      '#rdftype' => ''
+        ];
     return $info;
   }
 
@@ -32,21 +29,23 @@ class WebformLoC extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public static function getCompositeElements(array $element) {
+
     $elements = [];
     $vocab = 'subjects';
     $rdftype = 'thing';
-  if (isset($element['#vocab'])) {
-    $vocab = $element['#vocab'];
-  }
-  if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
-    $rdftype = trim($element['#rdftype']);
-  }
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+      $rdftype = trim($element['#rdftype']);
+    }
+
     $class = '\Drupal\webform_strawberryfield\Element\WebformLoC';
     $elements['label'] = [
       '#type' => 'textfield',
       '#title' => t('Label'),
       '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
-      '#autocomplete_route_parameters' => array('auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10),
+      '#autocomplete_route_parameters' => ['auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10],
       '#attributes' => [
         'data-source-strawberry-autocomplete-key' => 'label',
         'data-target-strawberry-autocomplete-key' => 'uri'
@@ -62,18 +61,32 @@ class WebformLoC extends WebformCompositeBase {
     return $elements;
   }
 
+
+
   /**
    * {@inheritdoc}
    */
   public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
+    // @Disclaimer: This function is the worst and deceiving. Keeping it here
+    // So i never make this error again. Because of
+    // \Drupal\webform\Plugin\WebformElement\WebformCompositeBase::prepareMultipleWrapper
+    // Basically, in case of having multiple elements :: processWebformComposite
+    // is *never* called because it actually converts the 'WebformComposite' element into a
+    // \Drupal\webform\Element\WebformMultiple calling ::processWebformMultiple element
+    // So basically whatever i do here gets skipped if multiple elements are allowed.
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
-
-    //dpm('the element');
-    //dpm($element);
-
+    $vocab = 'subjects';
+    $rdftype = 'thing';
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+      $rdftype = trim($element['#rdftype']);
+    }
+    $element['label']["#autocomplete_route_parameters"] =
+      ['auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
     return $element;
   }
-
 
   /**
    * @param array $element
@@ -92,5 +105,6 @@ class WebformLoC extends WebformCompositeBase {
     $element['#attributes']['data-strawberry-autocomplete'] = 'LoC';
     return $element;
   }
+
 
 }

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -11,6 +11,7 @@ namespace Drupal\webform_strawberryfield\Plugin\WebformElement;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 
 /**
  * Provides an 'LoC Heading' element.
@@ -29,26 +30,54 @@ class WebformLoC extends WebformCompositeBase {
 
 
   public function getDefaultProperties() {
-    $properties = [
+
+    $properties = parent::getDefaultProperties() + [
         'vocab' => 'subjects',
         'rdftype' => 'FullNameElement',
       ] + parent::getDefaultProperties();
     return $properties;
+
   }
 
   public function prepare(
     array &$element,
     WebformSubmissionInterface $webform_submission = NULL
   ) {
-    parent::prepare(
-      $element,
-      $webform_submission
-    );
+
     // @TODO explore this method to act on submitted data v/s element behavior
-    // e.g $webform_submission->getData());
-    // $vocab = $this->getElementProperty($element, 'vocab');
+
+    $vocab = $this->getElementProperty($element, 'vocab');
+    $rdftype = $this->getElementProperty($element, 'rdftype');
 
   }
+
+  /**
+   * Set multiple element wrapper.
+   *
+   * @param array $element
+   *   An element.
+   */
+  protected function prepareMultipleWrapper(array &$element) {
+
+    parent::prepareMultipleWrapper($element);
+    // Finally!
+    // This is the last chance we have to affect the render array
+    // This is where the original element type is also
+    // swapped by webform_multiple
+    // breaking all our #process callbacks.
+    $vocab = 'subjects';
+    $rdftype = 'thing';
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+      $rdftype = trim($element['#rdftype']);
+    }
+    $element['#element']['label']["#autocomplete_route_parameters"] =
+      ['auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
+
+  }
+
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -17,8 +17,8 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @WebformElement(
  *   id = "webform_metadata_loc",
- *   label = @Translation("LoC heading"),
- *   description = @Translation("Provides a form element to reconciliate against LoC Headings."),
+ *   label = @Translation("LoC Linked Open Data"),
+ *   description = @Translation("Provides a form element to reconciliate against LoC Headings and similar LoD Sources."),
  *   category = @Translation("Composite elements"),
  *   multiline = TRUE,
  *   composite = TRUE,
@@ -32,7 +32,7 @@ class WebformLoC extends WebformCompositeBase {
     $properties = [
         'vocab' => 'subjects',
         'rdftype' => 'FullNameElement',
-      ] + $this->getDefaultBaseProperties();
+      ] + parent::getDefaultProperties();
     return $properties;
   }
 


### PR DESCRIPTION
Bug fix.  Regression i introduced via #52. I made a mistake. A tiny one. This is my redemption.

Basically i was removing all the default properties by not calling the correct parent function. Now i am. 
1AM Update: the error was deeper and not mine to be honest. Its a long story but webform module, on composite elements like this changes the type of the element on the fly, before rendering if you allow more than a single value. Since Form Elements (render elements) depend a lot on #process callbacks to do things like reading the settings we allow (in this case which vocabulary or what RDF type), those settings can not longer be used anywhere. So i had to to use all whats left of my brain and finally found a spot, just before that horror story happens to put our values and allow the autocomplete to act dynamically accordingly to our settings. yeah i know. Who cares?
Going to sleep. @giancarlobi  is about to get up! (without testing, can you just quickly look at the code?) Thanks

Cheers


 