### PR TITLE
ISSUE-26: Add a Cancel Edit button to Webform widget editing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     ],
     "require": {
-        "ml/json-ld": "^1.1",
+        "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
         "strawberryfield/strawberryfield":"dev-8.x-1.0-beta3",
         "strawberryfield/format_strawberryfield":"dev-8.x-1.0-beta3",
-        "drupal/webform": "^5.9",
+        "drupal/webform": "^5.19",
         "drupal/webform_views": "^5.0"
     }
 }

--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -21,17 +21,27 @@
             if ($('.path-node fieldset[data-strawberryfield-selector="strawberry-webform-widget"]').length) {
                 if ($('.webform-confirmation',context).length) {
                     // Exclude webform own edit-actions containter
+                    /* And hide, if present the close button but only show save if all are ready.
+                    @TODO we need to figure out what if there are many webforms open at different states in the same
+                    Entity Form.
+                    */
                     $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
-                } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
-                    $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
-                }
-                var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
-                if ($moderationstate.length) {
+                    $('.webform-confirmation').closest('[data-strawberryfield-selector="strawberry-webform-widget"]').each(function() {
+                        var $id = $(this).attr('id') + '-strawberry-webform-close-modal';
+                        $('#' + $id).toggleClass('js-hide');
+                    })
 
-                    /* var $select = $moderationstate.on('change', function () {
-                        $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
 
-                    }); */
+               } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
+                   $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
+               }
+               var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
+               if ($moderationstate.length) {
+
+                   /* var $select = $moderationstate.on('change', function () {
+                       $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
+
+                   }); */
                 }
                 var $nodetitle = $('input[data-drupal-selector="edit-title-0-value"]', context).once('show-hide-actions');
                 if ($nodetitle.length) {

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
@@ -339,15 +339,17 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
 
       // Webform controller wrapper URL
       $this_field_name = $this->fieldDefinition->getName();
+      //@see \Drupal\webform_strawberryfield\Controller\StrawberryRunnerModalController
+      // We need to assume nothing of this will ever work without AJAX/JS.
 
       $webform_controller_url= Url::fromRoute('webform_strawberryfield.modal_webform',
         [
           'webform' =>  $my_webform_machinename,
           'source_entity_types' => "$entity_type:$bundle",
           'state'=> "$entity_uuid:$this_field_name:$delta:$this_widget_id",
+          'modal' => FALSE
         ]
       );
-
       $element['strawberry_webform_open_modal']  = [
         '#type' => 'link',
         '#title' => $this->t('Edit @a', array('@a' => $this->getSetting('placeholder')?: $items->getName())),
@@ -361,7 +363,26 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
           ],
         ],
       ];
-
+      $webform_controller_url_close= Url::fromRoute('webform_strawberryfield.close_modal_webform',
+        [
+          'state'=> "$entity_uuid:$this_field_name:$delta:$this_widget_id",
+          'modal' => FALSE,
+        ]
+      );
+      $element['strawberry_webform_close_modal'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Cancel @a editing', array('@a' => $this->getSetting('placeholder')?: $items->getName())),
+        '#url' => $webform_controller_url_close,
+        '#attributes' => [
+          'class' => [
+            'use-ajax',
+            'button',
+            'btn-warning',
+            'btn',
+            'js-hide'
+          ],
+        ],
+      ];
     }
 
 
@@ -524,6 +545,5 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     return $activitystream->getAsBody()?:[];
 
   }
-
 
 }

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
@@ -222,7 +222,7 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
         $my_webform->toUrl()->setAbsolute()->toString()
       );
     } catch (EntityMalformedException $e) {
-      return $this->_exceptionElement($items, $delta, $element,$form, $form_state);
+        return $this->_exceptionElement($items, $delta, $element,$form, $form_state);
     }
 
     $this_field_name = $this->fieldDefinition->getName();
@@ -246,6 +246,13 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
         'webform' =>  $my_webform_machinename,
         'source_entity_types' => "$entity_type:$bundle",
         'state'=> "$entity_uuid:$this_field_name:$delta:$this_widget_id",
+        'modal' => FALSE
+      ]
+    );
+    $webform_controller_url_close= Url::fromRoute('webform_strawberryfield.close_modal_webform',
+      [
+        'state'=> "$entity_uuid:$this_field_name:$delta:$this_widget_id",
+        'modal' => FALSE,
       ]
     );
 
@@ -277,6 +284,21 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
           'button',
           'btn-primary',
           'btn'
+        ],
+      ],
+    ];
+
+    $element['strawberry_webform_close_modal'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Cancel @a editing', array('@a' => $this->getSetting('placeholder')?: $items->getName())),
+      '#url' => $webform_controller_url_close,
+      '#attributes' => [
+        'class' => [
+          'use-ajax',
+          'button',
+          'btn-warning',
+          'btn',
+          'js-hide'
         ],
       ],
     ];

--- a/webform_strawberryfield.info.yml
+++ b/webform_strawberryfield.info.yml
@@ -2,12 +2,11 @@ name: Strawberry Field Webform Integration
 description: Provides Webform integrations to feed a field of Strawberries.
 package: Archipelago
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 php: 7.1
 dependencies:
   - 'drupal:field'
   - 'drupal:file'
-  - 'drupal:system (>= 8.7)'
   - 'drupal:user'
   - 'strawberryfield'
-  - 'webform:webform (>= 8.x-5.3)'
+  - 'webform:webform (>= 8.x-5.19)'

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -340,20 +340,12 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
         $iiifserversettings->get('pub_server_url'),
         $iiifserversettings->get('int_server_url')
       );
-      // Deal with Drupal 8.8.x v/s 8.7
-      if (method_exists(
-        \Drupal::service('stream_wrapper_manager'),
-        'getTarget'
-      )) {
-        $iiifidentifier = urlencode(
-          \Drupal::service('stream_wrapper_manager')->getTarget(
+      // Deal with Drupal 8.8.x only now
+      $iiifidentifier = urlencode(
+        \Drupal::service('stream_wrapper_manager')->getTarget(
             $file->getFileUri()
-          )
-        );
-      }
-      else {
-        $iiifidentifier = urlencode(file_uri_target($file->getFileUri()));
-      }
+        )
+      );
 
       if ($iiifidentifier == NULL || empty($iiifidentifier)) {
         // Nothing to do, lets leave this untouched.

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -323,7 +323,14 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
     $format = $variables['format'];
 
     $uri = $file->getFileUri();
+    $filename = $file->getFilename();
+    $fileextension = pathinfo(
+      $filename,
+      PATHINFO_EXTENSION
+    );
+
     $url = Url::fromUri(file_create_url($uri));
+
     if (!$file->isTemporary()) {
 
       $iiifserversettings = \Drupal::config(
@@ -380,10 +387,7 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
 
       $route_parameters = [
         'uuid' => $file->uuid(),
-        'format' => 'default.' . pathinfo(
-            $file->getFilename(),
-            PATHINFO_EXTENSION
-          ),
+        'format' => 'default.' . $fileextension,
       ];
       $publicurl = Url::fromRoute(
         'format_strawberryfield.tempiiifbinary',
@@ -403,7 +407,7 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
         $cache_key = md5($uri);
         $templocation = \Drupal::service('file_system')->copy(
           $uri,
-          'temporary://sbr_' . $cache_key . '_' . basename($uri),
+          'temporary://sbr_' . $cache_key . '.' . $fileextension,
           FileSystemInterface::EXISTS_REPLACE
         );
         $templocation = \Drupal::service('file_system')->realpath(
@@ -417,18 +421,14 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
       }
       if ($templocation) {
         $result = exec(
-          'exiftool -json -q -a -gps:all -Common "-gps*" -xmp:all  -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellcmd($templocation),
+          'exiftool -json -q -a -gps:all -Common "-gps*" -xmp:all  -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellarg(
+            $templocation
+          ),
           $output,
           $status
         );
-        if ($status != 0) {
-          // This message is annoying. Appears over and over.
-          /*\Drupal::service('messenger')
-            ->addMessage(
-              t('Ups. We could not get EXIF from your file. Sorry.')
-            );*/
-        }
-        else {
+        if ($status == 0) {
+
           $more_str = implode('', $output);
           $json = json_decode($more_str, TRUE);
           $json_error = json_last_error();
@@ -460,9 +460,8 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
       }
     }
 
-    $extension = pathinfo($uri, PATHINFO_EXTENSION);
     $is_image = in_array(
-      $extension,
+      $fileextension,
       ['gif', 'png', 'jpg', 'jpeg', 'jp2', 'tiff']
     );
 
@@ -491,8 +490,8 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
       '#uri' => $url,
       '#attributes' => [
         'class' => ['webform-strawberryfield-image-file'],
-        'alt' => $file->getFilename(),
-        'title' => $file->getFilename(),
+        'alt' => $filename,
+        'title' => $filename,
         'style' => "max-width:{$max_width}px;height:auto",
       ],
     ];
@@ -531,6 +530,5 @@ function webform_strawberryfield_preprocess_webform_element_image_file(
           break;
       }
     }
-
   }
 }


### PR DESCRIPTION
See #26 

Since 26 is a macro issue, this is just a step forward: This pull adds a Cancel Button to any ADO via a Webform Editing session (editing, not creating from 0) which triggers also Edit Buttons from the main Node Form to be displayed again and the original "Edit SOMEPLACEHOLDER TEXT YOU DECIDED ON" to appear back. Logic is simple and most of that is Ajax Commands being send as response to the existing Model Controller we built back in the days: 
Also covers

#56 Drupal 9!

# Other Improvements:
 - Modal popup again possible via code. `@TODO:` Expose as an setting to the Widget. So people can decide if they want the inline form (as they get now) or the popup a new one (as they got in 2019)
- EXIF was having trouble to process files with names, etc when that option was enabled on upload. To be honest i don't feel EXIF should be shown at all during upload, not sure if that use case which comes from a particular project applies to anything else. But since the preview of image/video can be disabled per Webform Element, i kinda feel i won't give removing it for now a priority. File naming and escaping is now corrected.
- Both, inline and not inline widget got the Cancel button and there is also some JS driven logic to hide it at the end, when the submission is done but before saving the Node/ADO.