### PR TITLE
Issue 26b: declutter webform ingest

### DIFF
--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -34,8 +34,8 @@
 
 
                } else if (
-                    $('div.field--widget-strawberryfield-webform-inline-widget').length ||
-                    $('div.field--widget-strawberryfield-webform-widget').length
+                    $('div.field--widget-strawberryfield-webform-inline-widget form.webform-submission-form').length ||
+                    $('div.field--widget-strawberryfield-webform-widget form.webform-submission-form').length
                    )
                {
                    $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();

--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -26,6 +26,7 @@
                     Entity Form.
                     */
                     $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
+                    $('.path-node .node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').show();
                     $('.webform-confirmation').closest('[data-strawberryfield-selector="strawberry-webform-widget"]').each(function() {
                         var $id = $(this).attr('id') + '-strawberry-webform-close-modal';
                         $('#' + $id).toggleClass('js-hide');
@@ -34,6 +35,7 @@
 
                } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
                    $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
+                   $('.path-node .node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').hide();
                }
                var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
                if ($moderationstate.length) {

--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -33,7 +33,11 @@
                     })
 
 
-               } else if ($('div.field--widget-strawberryfield-webform-inline-widget').length) {
+               } else if (
+                    $('div.field--widget-strawberryfield-webform-inline-widget').length ||
+                    $('div.field--widget-strawberryfield-webform-widget').length
+                   )
+               {
                    $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
                    $('.path-node .node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').hide();
                }

--- a/src/Element/WebformNominatim.php
+++ b/src/Element/WebformNominatim.php
@@ -317,6 +317,9 @@ class WebformNominatim extends WebformLocationBase {
         );
       }
     }
+    // Reset current selection, if any. That way we can deselect wrongly made options
+    // By researching.
+    $form_state->set($my_geosjonkey.'-table-option', NULL);
     // Rebuild the form.
     $form_state->setRebuild(TRUE);
   }

--- a/src/Element/WebformNominatim.php
+++ b/src/Element/WebformNominatim.php
@@ -168,7 +168,6 @@ class WebformNominatim extends WebformLocationBase {
             'category' => $feature->value->properties->category,
           ];
         }
-        dpm($form_state->get($my_geosjonkey.'-table-option'));
         $element['feature']['table'] = [
           '#title' => t('OpenStreet Map Nominatim Best Matches'),
           '#type' => 'tableselect',

--- a/src/Element/WebformNominatim.php
+++ b/src/Element/WebformNominatim.php
@@ -168,6 +168,7 @@ class WebformNominatim extends WebformLocationBase {
             'category' => $feature->value->properties->category,
           ];
         }
+        dpm($form_state->get($my_geosjonkey.'-table-option'));
         $element['feature']['table'] = [
           '#title' => t('OpenStreet Map Nominatim Best Matches'),
           '#type' => 'tableselect',
@@ -320,6 +321,11 @@ class WebformNominatim extends WebformLocationBase {
     // Reset current selection, if any. That way we can deselect wrongly made options
     // By researching.
     $form_state->set($my_geosjonkey.'-table-option', NULL);
+    $userinput = $form_state->getUserInput();
+    // Only way to get that tableselect form to rebuild completely
+    unset($userinput[$top_element['#name']]['feature']['table']);
+    $form_state->setUserInput($userinput);
+
     // Rebuild the form.
     $form_state->setRebuild(TRUE);
   }

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
@@ -324,7 +324,8 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
       '#id' => 'webform_output_' . $this_widget_id,
       '#default_value' => $current_value['creation_method'],
     ];
-
+    // Because the actual form attaches via AJAX the library/form alter never triggers my friends.
+    $element['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.nodeactions.toggle';
     return $element;
   }
 


### PR DESCRIPTION
As always this is moving #26 forward.

- Hide Save/Moderation State in every multistep widget (except raw) we provide and make JQuery selects more precise
- Make sure it shows back when needed!
- Attach JS library directly on the normal webform widget (the one that is not inline) just in case form alter/JS does not work via ajax. There is a back and forth in D8/9 core about the issue so better to be safe
