### PR TITLE
Beta3 Regression fix -- Multiple with Table headers

### DIFF
--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -79,9 +79,28 @@ class WebformLoC extends WebformCompositeBase {
     }
 
     $rdftype = $rdftype ?: $this->getDefaultProperty($rdftype);
-
-    $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
-      ['auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
+    // This seems to have been an old Webform module variation
+    // Keeping it here until sure its not gone for good
+    if (isset($element['#element']['#webform_composite_elements']['label'])) {
+      $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'loc',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+    // For some reason i can not understand, when multiples are using
+    // Tables, the #webform_composite_elements -> 'label' is not used...
+    if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {
+      $element['#element']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'loc',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
   }
 
 


### PR DESCRIPTION
While doing some new code on 1.0.0RC1 i found this annoying issue in beta3. Just in case, for people running beta3, i prefer to fix this now since it was introduced really by a change in how Webform module manages the multipl wrappers around a composite element and multiple behavior. 
Basically if you are using LoC rdftypes (e.g CorporateName) and also multiple and also Table headers, for some reason out of my understanding webform decides to not reuse values set by the composite builder method inside the element. This gets over the issue. Same change under a different commit is already applied to ISSUE-60 branch that will go into 1.0.0-RC1. Feels a bit messy but reason is ISSUE-60 also contains dependencies on newer code that we can not put here as a regression fix. 
This is mostly equivalent to https://github.com/esmero/webform_strawberryfield/commit/2d3aecd193ca3fc488964c52b47245727418afea