### PR TITLE
ISSUE-85 and ISSUE-84: Allow multivalued Webform elements to read single valued JSON data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
         "strawberryfield/format_strawberryfield":"dev-1.0.0-RC1",
         "drupal/webform": "^5.19 || ^6.0",
-        "drupal/webform_views": "^5.0",
         "ramsey/uuid": "^4"
     }
 }

--- a/src/Controller/StrawberryRunnerModalController.php
+++ b/src/Controller/StrawberryRunnerModalController.php
@@ -149,6 +149,20 @@ class StrawberryRunnerModalController extends ControllerBase
         }
         else {
             $data['data'] = $data_defaults + json_decode($stored_value,true);
+          // In case the saved data is "single valued" for a key
+          // But the corresponding webform element is not
+          // we cast to it multi valued so it can be read/updated
+          /* @var \Drupal\webform\WebformInterface $webform */
+          $webform_elements  = $webform->getElementsInitializedFlattenedAndHasValue();
+          $elements_in_data = array_intersect_key($webform_elements, $data['data']);
+          if (is_array($elements_in_data) && count($elements_in_data)>0) {
+            foreach($elements_in_data as $key => $elements_in_datum) {
+              if (isset($elements_in_datum['#webform_multiple']) &&
+                $elements_in_datum['#webform_multiple']!== FALSE) {
+                $data['data'][$key] = (array) $data['data'][$key];
+              }
+            }
+          }
         }
 
       $confirmation_message = $webform->getSetting('confirmation_message', FALSE);


### PR DESCRIPTION
See #85 and #84 

The last one is just clean up of old code we no (hopefully!) need anymore since Event Subscribers are in charge of persisting and classifying. Makes webform operations faster. But I need to test this before merging.