### PR TITLE
ISSUE-92: adds missing #title  to WebformMultiAgent Agent Type input

### DIFF
--- a/src/Element/WebformMultiAgent.php
+++ b/src/Element/WebformMultiAgent.php
@@ -61,6 +61,8 @@ class WebformMultiAgent extends WebformCompositeBase {
 
     $elements['agent_type'] = [
       '#type' => 'select',
+      '#title' => t('Agent Type'),
+      '#title_display' => 'invisible',
       '#options' => [
         'corporate' => 'Corporate',
         'personal' => 'Personal',


### PR DESCRIPTION
See #92 

This is a super tiny fix but gets rid of the message. Pretty sure `#title` element key is not a requirement, but it is good to have, even if we are actually hiding it.

@alliomeria 