### PR TITLE
Issue 95: make Hotspot Ids really unique and move to RC2 updating Webform Module Version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
-        "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
-        "strawberryfield/format_strawberryfield":"dev-1.0.0-RC1",
-        "drupal/webform": "^5.19 || ^6.0",
+        "strawberryfield/strawberryfield":"dev-1.0.0-RC2",
+        "strawberryfield/format_strawberryfield":"dev-1.0.0-RC2",
+        "drupal/webform": "^5.23 || ^6.0",
         "ramsey/uuid": "^4"
     }
 }

--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -13,6 +13,7 @@ use Drupal\webform_strawberryfield\Ajax\AddHotSpotCommand;
 use Drupal\webform_strawberryfield\Ajax\RemoveHotSpotCommand;
 use Drupal\webform\Utility\WebformElementHelper;
 use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Ramsey\Uuid\Uuid;
 
 
 /**
@@ -500,7 +501,7 @@ class WebformPanoramaTour extends WebformCompositeBase {
               'label' =>  [
                 '#type' => 'html_tag',
                 '#tag' => 'p',
-                '#value' => isset($hotspot->text) ? $hotspot->text ." ". $hotspot->id." " : t('no name'),
+                '#value' => isset($hotspot->text) ? $hotspot->text ." (ID: ". $hotspot->id.")" : t('no name'),
               ],
               'operations' => $delete_hot_spot_button
             ];
@@ -830,7 +831,12 @@ class WebformPanoramaTour extends WebformCompositeBase {
       $hotspot->text = $form_state->getValue(
         [$element_name, 'hotspots_temp', 'label']
       );
-      $hotspot->id = $element_name . '_' . $current_scene . '_' .(count($existing_objects) + 1);
+      // Instead of trying to figure out which Incremental ID is next
+      // stop wasting cycles and generate a UUID for it and prefix it. Will
+      // also confuse users less after deleting/adding/deleting and ending
+      // with non consecutive Ids.
+      $newid = Uuid::uuid4();
+      $hotspot->id = $element_name . '_' . $current_scene . '_' . $newid->toString();
       if ($hotspot->type == 'url') {
         $hotspot->URL = $hotspot->url;
         $hotspot->type = 'info';


### PR DESCRIPTION
# What is this?

A bug fix. See #95 to read more about my adventures at not thinking straight.
This pull changes incremental ID Hotspot ids to UUID suffixed ones. That way when people delete/add/delete/add the actual sequence does not matter anymore and we have no more Conflicting HTML Ids and Ajax chananigans 🤦 

I also used the occasion to move to RC2, upgrade to webform 5.23 on Drupal 8 (still on 6.0 for 9.1). 
 