### PR TITLE
ISSUE-100 - Fix when not $element['#multiple']

### DIFF
--- a/src/Plugin/WebformElement/WebformMetadataDate.php
+++ b/src/Plugin/WebformElement/WebformMetadataDate.php
@@ -342,7 +342,7 @@ class WebformMetadataDate extends MetadataDateBase {
     else {
       $filtered_value = array_filter($value);
       if (count($filtered_value) > 1 ) {
-        $newvalue[] = $value;
+        $newvalue = $value;
       }
     }
     $webform_submission->setElementData($key,$newvalue);


### PR DESCRIPTION
ISSUE-100 --- fix a bug in \WebformMetadataDate::preSave that caused single value metadata date fields to be saved into json as if they were multi-valued. This resulted in them not being read back into the webform correctly after saving.

See https://github.com/esmero/webform_strawberryfield/commit/04867f1ccaef066c4a5a147946ba487d7213ca56#r47431992