### PR TITLE
webform_options_twig: added twig extensions for webform options label rendering

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\webform_strawberryfield;
+
+use Drupal\webform\Entity\Webform;
+use Drupal\webform\Entity\WebformOptions;
+
+
+/**
+ * Class TwigExtension.
+ *
+ * @package Drupal\webform_strawberryfield
+ */
+class TwigExtension extends \Twig_Extension {
+
+  /**
+   * @inheritDoc
+   */
+  public function getFunctions() {
+    return [
+      new \Twig_SimpleFunction('sbf_webform_select_element_option_label',
+        [$this, 'webformSelectElementOptionLabel']),
+      new \Twig_SimpleFunction('sbf_webform_option_label',
+        [$this, 'webformOptionLabel']),
+    ];
+  }
+
+  /**
+   * Given a webform select list element's option value, returns the corresponding option label.
+   *
+   * @param  string  $webform_id
+   * @param  string  $element_id
+   * @param  string|null  $option
+   *
+   * @return null|string
+   *   The option label if found. Otherwise null.
+   */
+  public function webformSelectElementOptionLabel(
+    string $webform_id,
+    string $element_id,
+    ?string $option = NULL
+  ): ?string {
+    if(is_string($option) && $option) {
+      $webform = Webform::load($webform_id);
+      if($webform) {
+        $element = $webform->getElement($element_id);
+        if(!empty($element) && !empty($element['#options']) && !empty($element['#options'][$option])) {
+          return $element['#options'][$option];
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Given a webform option list and a value, returns the corresponding option label.
+   *
+   * @param  string  $webform_option_list_id
+   * @param  string|null  $option
+   *
+   * @return null|string
+   *   The option label if found. Otherwise null.
+   */
+  public function webformOptionLabel(
+    string $webform_option_list_id,
+    ?string $option = NULL
+  ): ?string {
+    if(is_string($option) && $option) {
+      $webform_option_list = WebformOptions::load($webform_option_list_id);
+        if(!empty($webform_option_list) && !empty($webform_option_list['#options']) && !empty($webform_option_list['#options'][$option])) {
+          return $webform_option_list['#options'][$option];
+      }
+    }
+    return NULL;
+  }
+
+}

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -67,8 +67,11 @@ class TwigExtension extends \Twig_Extension {
   ): ?string {
     if(is_string($option) && $option) {
       $webform_option_list = WebformOptions::load($webform_option_list_id);
-        if(!empty($webform_option_list) && !empty($webform_option_list['#options']) && !empty($webform_option_list['#options'][$option])) {
-          return $webform_option_list['#options'][$option];
+      if (!empty($webform_option_list)) {
+        $options = $webform_option_list->getOptions();
+        if (!empty($options) && !empty($options[$option])) {
+          return $options[$option];
+        }
       }
     }
     return NULL;

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -44,9 +44,20 @@ class TwigExtension extends \Twig_Extension {
       $webform = Webform::load($webform_id);
       if($webform) {
         $element = $webform->getElement($element_id);
-        if(!empty($element) && !empty($element['#options']) && !empty($element['#options'][$option])) {
-          return $element['#options'][$option];
+        if (!empty($element)) {
+          if (!empty($element['#options'][$option])) {
+            return $element['#options'][$option];
+          }
+          elseif (!empty($element['#vocabulary'])) {
+            $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')
+              ->loadByProperties(['tid' => $option, 'vid' => $element['#vocabulary']]);
+            $term = reset($term);
+            if($term && $term->label()) {
+              return $term->label();
+            }
+          }
         }
+
       }
     }
     return NULL;
@@ -65,12 +76,12 @@ class TwigExtension extends \Twig_Extension {
     string $webform_option_list_id,
     ?string $option = NULL
   ): ?string {
-    if(is_string($option) && $option) {
+    if (is_string($option) && $option) {
       $webform_option_list = WebformOptions::load($webform_option_list_id);
       if (!empty($webform_option_list)) {
-        $options = $webform_option_list->getOptions();
-        if (!empty($options) && !empty($options[$option])) {
-          return $options[$option];
+        $labels = $webform_option_list->getOptions();
+        if (!empty($labels) && !empty($labels[$option])) {
+          return $labels[$option];
         }
       }
     }

--- a/webform_strawberryfield.services.yml
+++ b/webform_strawberryfield.services.yml
@@ -4,3 +4,7 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger', '@logger.factory', '@tempstore.private']
+  webform_strawberryfield.twig.TwigExtension:
+    class: Drupal\webform_strawberryfield\TwigExtension
+    tags:
+      - {name: twig.extension}


### PR DESCRIPTION
# WIP/DRAFT
I'm just creating this PR to get feedback. It may turn into a real PR.
See https://github.com/esmero/webform_strawberryfield/pull/99
and https://github.com/esmero/webform_strawberryfield/issues/96

# What?
Creates two twig extensions for webform select lists so that when a value is stored in the json, we can use twig to render the label corresponding to that value. 

- `sbf_webform_select_element_option_label` will work for any value saved by a webform select widget. It takes as arguments, the machine name of the webform and the machine name of the element in the webform, and the value. It loads the webform, then loads the element, then looks for the value in the element's `#options` list  and returns the label corresponding to it. 
- `sbf_webform_option_label` requires knowing what webform options entity was used to provide the value/label pair. It takes as arguments the machine name for the webform options list, and the value. It loads the options list, looks for the value in that list, and returns the label if it is found.

# To Test
- Create a webform with some select list elements that will save their value(s) to an ADO strawberryfield json.
- Create and test a metadata display with twig to convert the values to labels. Example:
```
{{ sbf_webform_select_element_option_label('testing_value_label_element', 'test_select', data.test_select) }}
{{ sbf_webform_option_label('languages_iso_639_2', data.test_select) }}
```