### PR TITLE
ISSUE-122: Europeana Entity Suggest Webform element and Controller + cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # Webform Strawberry Field
-A module that provides Drupal 8 Webform ( == awesome piece of code) integrations for StrawberryField so you can really have control over your Metadata ingests. This is part of the Archipelago Commons Project.
+A module that provides Drupal 8/9 Webform ( == awesome piece of code) integrations for StrawberryField so you can really have control over your Metadata ingests. This is part of the Archipelago Commons Project.
 
-# Disclaimer
-This is an experimental module, use at your own risk 
+# Setup
+
+This module provides many LoD Autocomplete suggester Webform Elements, but only *The Europeana Entity Suggester* for now requires you to provide an `APIKEY`.
+To be able to use the Europeana Suggester edit your Drupal `settings.php` file (located normally in `web/sites/default/settings.php`) and add the following line:
+
+```PHP
+$settings['webform_strawberryfield.europeana_entity_apikey'] = 'thekey';
+```
+
+Save and clear caches.
+
+In its current state the Europeana Entity API (Alpha 0.5) uses a static APIKEY (not the same as other APIs) and can be found at https://pro.europeana.eu/page/entity#suggest
+
+If using https://github.com/esmero/archipelago-deployment this is not needed and will be provided by the deployment.
 
 ## Help
 
@@ -18,6 +30,7 @@ Having issues with this module? Check out the Archipelago Commons google groups 
 
 * [Diego Pino](https://github.com/DiegoPino)
 * [Giancarlo Birello](https://github.com/giancarlobi)
+* [Allison Lund](https://github.com/alliomeria)
 
 ## Acknowledgments
 

--- a/config/schema/webform_strawberryfield.schema.yml
+++ b/config/schema/webform_strawberryfield.schema.yml
@@ -1,3 +1,9 @@
+webform_strawberryfield.settings:
+  type: config_object
+  mapping:
+    europeana_entity_apikey:
+      type: string
+      label: 'Europeana Entity API Secret key'
 field.widget.settings.strawberryfield_webform_inline_widget:
   type: config_object
   label: 'Webform Inline Widget Schema'

--- a/js/hidenodeaction-webform_strawberryfield.js
+++ b/js/hidenodeaction-webform_strawberryfield.js
@@ -18,28 +18,27 @@
     Drupal.behaviors.webformstrawberryHideNodeActions = {
         attach: function (context, settings) {
             // Only react if the document contains a strawberry webform widget
-            if ($('.path-node fieldset[data-strawberryfield-selector="strawberry-webform-widget"]').length) {
+            if ($('.node-form fieldset[data-strawberryfield-selector="strawberry-webform-widget"]').length) {
                 if ($('.webform-confirmation',context).length) {
                     // Exclude webform own edit-actions containter
                     /* And hide, if present the close button but only show save if all are ready.
                     @TODO we need to figure out what if there are many webforms open at different states in the same
                     Entity Form.
                     */
-                    $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
-                    $('.path-node .node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').show();
+                    $('.node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
+                    $('.node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').show();
                     $('.webform-confirmation').closest('[data-strawberryfield-selector="strawberry-webform-widget"]').each(function() {
                         var $id = $(this).attr('id') + '-strawberry-webform-close-modal';
                         $('#' + $id).toggleClass('js-hide');
                     })
-
 
                } else if (
                     $('div.field--widget-strawberryfield-webform-inline-widget .webform-submission-form').length ||
                     $('div.field--widget-strawberryfield-webform-widget .webform-submission-form').length
                    )
                {
-                   $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
-                   $('.path-node .node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').hide();
+                   $('.node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').hide();
+                   $('.node-form div[data-drupal-selector="edit-footer"]').not('.webform-actions').hide();
                }
                var $moderationstate = $('select[data-drupal-selector="edit-moderation-state-0-state"]', context).once('show-hide-actions');
                if ($moderationstate.length) {
@@ -52,8 +51,7 @@
                 var $nodetitle = $('input[data-drupal-selector="edit-title-0-value"]', context).once('show-hide-actions');
                 if ($nodetitle.length) {
                     var $select = $nodetitle.on('input', function () {
-                        $('.path-node .node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
-
+                        $('.node-form div[data-drupal-selector="edit-actions"]').not('.webform-actions').show();
                     });
                 }
             }

--- a/src/Controller/StrawberryRunnerModalController.php
+++ b/src/Controller/StrawberryRunnerModalController.php
@@ -34,8 +34,7 @@ class StrawberryRunnerModalController extends ControllerBase
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    *   Thrown when not be accessible.
    */
-  public function openModalForm(WebformInterface $webform = NULL, Request $request)
-  {
+  public function openModalForm(WebformInterface $webform = NULL, Request $request) {
 
     // @see \Drupal\archipel\Plugin\Field\FieldWidget\StrawberryFieldWebFormWidget::formElement
     //  Request Arguments we are expecting:
@@ -70,6 +69,8 @@ class StrawberryRunnerModalController extends ControllerBase
     // throw new \InvalidArgumentException('Data type must be in the form of
     // "entityUUID:FIELD_NAME:DELTA:someSHA1hashthatidentifiesthegtriggeringwidget"');
 
+    /* @var $source_entity \Drupal\Core\Entity\FieldableEntityInterface */
+    $source_entity = NULL;
     // If uuid does not exist then it may be a new ADO. That is Ok.
     if ($source_uuid && Uuid::isValid($source_uuid)) {
       try {
@@ -100,8 +101,6 @@ class StrawberryRunnerModalController extends ControllerBase
           $notfound, ['width' => '90%']));
         return $response;
       }
-      //@var $source_entity \Drupal\Core\Entity\FieldableEntityInterface */
-      $source_entity = NULL;
 
       foreach ($entities as $entity) {
         // Means there was an entity stored! hu!

--- a/src/Element/WebformEuropeana.php
+++ b/src/Element/WebformEuropeana.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\webform_strawberryfield\Element;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Element\WebformCompositeBase;
+
+
+/**
+ * Provides a webform element for a LoC element.
+ *
+ * @FormElement("webform_metadata_europeana")
+ */
+class WebformEuropeana extends WebformCompositeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+
+    $info =  parent::getInfo() + [
+      '#vocab' => 'agent',
+      '#rdftype' => 'thing'
+    ];
+    return $info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCompositeElements(array $element) {
+
+    $elements = [];
+    $vocab = 'agent';
+    $rdftype = 'thing';
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+
+    $class = '\Drupal\webform_strawberryfield\Element\WebformEuropeana';
+    $elements['label'] = [
+      '#type' => 'textfield',
+      '#title' => t('Label'),
+      '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
+      '#autocomplete_route_parameters' => ['auth_type' => 'europeana', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10],
+      '#attributes' => [
+        'data-source-strawberry-autocomplete-key' => 'label',
+        'data-target-strawberry-autocomplete-key' => 'uri'
+      ],
+
+    ];
+    $elements['uri'] = [
+      '#type' => 'url',
+      '#title' => t('Subject URL'),
+      '#attributes' => ['data-strawberry-autocomplete-value' => TRUE]
+    ];
+    $elements['label']['#process'][] =  [$class, 'processAutocomplete'];
+    return $elements;
+  }
+
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
+    // @Disclaimer: This function is the worst and deceiving. Keeping it here
+    // So i never make this error again. Because of
+    // \Drupal\webform\Plugin\WebformElement\WebformCompositeBase::prepareMultipleWrapper
+    // Basically, in case of having multiple elements :: processWebformComposite
+    // is *never* called because it actually converts the 'WebformComposite' element into a
+    // \Drupal\webform\Element\WebformMultiple calling ::processWebformMultiple element
+    // So basically whatever i do here gets skipped if multiple elements are allowed.
+    // Solution is acting here instead:
+    // \Drupal\webform_strawberryfield\Plugin\WebformElement\WebformLoC::prepareMultipleWrapper
+    $vocab = 'agent';
+    $rdftype = 'thing';
+
+    $element = parent::processWebformComposite($element, $form_state, $complete_form);
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+
+    $element['label']["#autocomplete_route_parameters"] =
+      ['auth_type' => 'europeana', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
+
+    return $element;
+  }
+
+  /**
+   * @param array $element
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * @param array $complete_form
+   *
+   * @return array
+   */
+  public static function processAutocomplete(&$element, FormStateInterface $form_state, &$complete_form) {
+    $element = parent::processAutocomplete($element, $form_state, $complete_form);
+    $element['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.metadataauth.autocomplete';
+    $element['#attached']['drupalSettings'] = [
+      'webform_strawberryfield_autocomplete' => [],
+    ];
+
+    $element['#attributes']['data-strawberry-autocomplete'] = 'europeana';
+    return $element;
+  }
+
+
+}

--- a/src/Element/WebformNominatim.php
+++ b/src/Element/WebformNominatim.php
@@ -261,7 +261,7 @@ class WebformNominatim extends WebformLocationBase {
   }
 
   /**
-   * Submit Hanlder for the Nominatim reconciliation call.
+   * Submit Handler for the Nominatim reconciliation call.
    *
    * @param array $form
    * @param \Drupal\Core\Form\FormStateInterface $form_state
@@ -306,7 +306,6 @@ class WebformNominatim extends WebformLocationBase {
         'search',
         5,
         $current_laguage
-
       );
       $nomitanim_response_encoded = $json_response->isSuccessful()
         ? $json_response->getContent() : [];

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
@@ -575,7 +575,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     // Who do we ask?
 
     $jsonarray["as:generator"] = $this->addActivityStream($form_state);
-    $jsonvalue = json_encode($jsonarray, JSON_PRETTY_PRINT);
+    $jsonvalue = json_encode($jsonarray);
     $values2[0]['value'] = $jsonvalue;
     // @TODO this no longer is part of wild strawberry field defintion. We already have other
     // ways of keeping track. Remove or deprecate.

--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormWidget.php
@@ -416,7 +416,7 @@ class StrawberryFieldWebFormWidget extends WidgetBase implements ContainerFactor
     // Who do we ask?
 
     $jsonarray["as:generator"] = $this->addActivityStream($form_state);
-    $jsonvalue  =  json_encode($jsonarray, JSON_PRETTY_PRINT);
+    $jsonvalue  =  json_encode($jsonarray);
     $values2[0]['value'] = $jsonvalue;
     // @TODO this no longer is part of wild strawberry field definition. We already have other
     // ways of keeping track. Remove or deprecate.

--- a/src/Plugin/WebformElement/WebformEuropeana.php
+++ b/src/Plugin/WebformElement/WebformEuropeana.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 12/2/18
+ * Time: 5:17 PM
+ */
+
+namespace Drupal\webform_strawberryfield\Plugin\WebformElement;
+
+use Drupal\Core\Site\Settings;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Provides an 'LoC Heading' element.
+ *
+ * @WebformElement(
+ *   id = "webform_metadata_europeana",
+ *   label = @Translation("Europeana Entity Suggest"),
+ *   description = @Translation("Provides a form element to reconciliate against Europeana's Entity Suggest API."),
+ *   category = @Translation("Composite elements"),
+ *   multiline = TRUE,
+ *   composite = TRUE,
+ *   states_wrapper = TRUE,
+ * )
+ */
+class WebformEuropeana extends WebformCompositeBase {
+
+
+  protected function defineDefaultBaseProperties() {
+    return [
+      'vocab' => 'agent',
+      'rdftype' => 'thing',
+    ];
+  }
+
+  public function getDefaultProperties() {
+    $properties = parent::getDefaultProperties() + [
+        'vocab' => 'agent',
+        'rdftype' => 'thing',
+      ] + parent::defineDefaultProperties()
+      + $this->defineDefaultBaseProperties();
+
+    return $properties;
+  }
+
+
+
+  public function prepare(
+    array &$element,
+    WebformSubmissionInterface $webform_submission = NULL
+  ) {
+
+    // @TODO explore this method to act on submitted data v/s element behavior
+  }
+
+  /**
+   * Set multiple element wrapper.
+   *
+   * @param array $element
+   *   An element.
+   */
+  protected function prepareMultipleWrapper(array &$element) {
+
+    parent::prepareMultipleWrapper($element);
+
+    // Finally!
+    // This is the last chance we have to affect the render array
+    // This is where the original element type is also
+    // swapped by webform_multiple
+    // breaking all our #process callbacks.
+    $vocab = 'agent';
+    $rdftype = 'thing';
+    $vocab = $this->getElementProperty($element, 'vocab');
+    $vocab = $vocab ?:  $this->getDefaultProperty($vocab);
+   if (isset($element['#element']['#webform_composite_elements']['label'])) {
+      $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'europeana',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+    // For some reason i can not understand, when multiples are using
+    // Tables, the #webform_composite_elements -> 'label' is not used...
+    if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {
+      $element['#element']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'europeana',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginLabel() {
+    return $this->elementManager->isExcluded('webform_metadata_europeana') ? $this->t('Europeana Entity') : parent::getPluginLabel();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatHtmlItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    return $this->formatTextItemValue($element, $webform_submission, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    $value = $this->getValue($element, $webform_submission, $options);
+
+    $lines = [];
+    if (!empty($value['uri'])) {
+      $lines[] = $value['uri'];
+    }
+
+    if (!empty($value['label'])) {
+      $lines[] = $value['label'];
+    }
+    return $lines;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+    $apikey = Settings::get('webform_strawberryfield.europeana_entity_apikey');
+    if ($apikey) {
+      $description = $this->t('See <a href="https://pro.europeana.eu/page/entity#suggest">Europeana Entity API</a>. Good! We found your Europeana Entity API key.');
+    } else {
+      $description = $this->t('See <a href="https://pro.europeana.eu/page/entity#suggest">Europeana Entity API</a>. Warning: This API requires an apikey. Please ask your Drupal admin to set it for you in <em>settings.php</em>');
+    }
+
+    $form['composite']['vocab'] = [
+      '#type' => 'select',
+      '#options' => [
+        'agent' => 'Europeana Agents',
+        'concept' => 'Europeana Concepts',
+        'place' => 'Europeana Places',
+      ],
+      '#title' => $this->t("What Europeana Autocomplete Entity Type to use."),
+      '#description' => $description,
+    ];
+    return $form;
+  }
+
+}


### PR DESCRIPTION
# What? Europeana?

See #122 

Europeana Accepts types: agent, place, concept.

Requires: an api key set inside settings.php. For now Europeana (Alpha 0.5 V) has a single one for everyone but this can change.

IMPROTANT: To test put this:
```PHP
$settings['webform_strawberryfield.europeana_entity_apikey'] = 'apidemo';
```
In your settings.php. If not the controller will not query and a message to the user (somewhere when the user is in the Page and not in the controller url of course)

The `API` is quite unstable and may change in the future so I see this as experimental. Actually the DOCS are not 1:1 with the API response anyways..

Also updates `README.md` and.. wait for it.

Caches queries/responses for a week. This should give some `LoD endpoints` some peace of mind and helps with repeating responses. Caches are dependent on the user and 500 codes, 401 and 404 codes are not cached. We may want to add somewhere a "clear all caches just for this" but for now it seems to work ok.

@giancarlobi @alliomeria should we have a "bypass" cache flag? Like for admins?
AGAIN: can only be tested if you add the settings

Test: http://localhost:8001/webform_strawberry/auth_autocomplete/europeana/concept/thing/?q=techno

And implemented in a webform

![Screen Shot 2021-05-31 at 5 01 59 PM](https://user-images.githubusercontent.com/6946023/120242042-000df480-c232-11eb-9493-1ebe4f2b5834.png)



