### PR TITLE
ISSUE-124: Inherit right "defineDefaultBaseProperties" for LoD webform elements

### DIFF
--- a/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryFieldWebFormInlineWidget.php
@@ -155,7 +155,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     // Where is this field being used, a node?
     $entity_type = $items->getEntity()->getEntityTypeId();
     $bundle = $items->getEntity()->bundle();
-    $bundle_label = $items->getEntity()->type->entity->label();
+    $bundle_label = isset($items->getEntity()->type) ? $items->getEntity()->type->entity->label() : '';
     $this_field_name = $this->fieldDefinition->getName();
 
     // So does the current loaded entity, where this widget is shown
@@ -232,9 +232,6 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     /** @var \Drupal\webform\WebformInterface $my_webform */
     $my_webform = Webform::load($my_webform_machinename);
     // Deals with any existing confirmation messages.
-    $confirmation_message = $my_webform->getSetting('confirmation_message', FALSE);
-    $confirmation_message = !empty($confirmation_message) && strlen(trim($confirmation_message)) > 0 ? $confirmation_message : $this->t(
-      'Thanks, you are all set! Please Save the content to persist the changes.');
 
     if ($my_webform == NULL) {
       // Well someone dropped the ball here
@@ -242,6 +239,10 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
       // or the original webform exists only in our hopes.
       return $this->_exceptionElement($items, $delta, $element, $form, $form_state);
     }
+    $confirmation_message = $my_webform->getSetting('confirmation_message', FALSE);
+    $confirmation_message = !empty($confirmation_message) && strlen(trim($confirmation_message)) > 0 ? $confirmation_message : $this->t(
+      'Thanks, you are all set! Please Save the content to persist the changes.');
+
     $form_state->set('webform_machine_name', $my_webform_machinename);
     try {
       $form_state->set(
@@ -502,7 +503,7 @@ class StrawberryFieldWebFormInlineWidget extends WidgetBase implements Container
     $element['strawberry_webform_widget']['creation_method'] = [
       '#type' => 'value',
       '#id' => 'webform_output_webform' . $form_state->get('strawberryfield_webform_widget_id'),
-      '#default_value' => $current_value['creation_method'],
+      '#default_value' => $current_value['creation_method'] ?? 'missing_webform',
     ];
 
     return $element;

--- a/src/Plugin/WebformElement/WebformEuropeana.php
+++ b/src/Plugin/WebformElement/WebformEuropeana.php
@@ -34,15 +34,14 @@ class WebformEuropeana extends WebformCompositeBase {
     return [
       'vocab' => 'agent',
       'rdftype' => 'thing',
-    ];
+    ] + parent::defineDefaultBaseProperties();
   }
 
   public function getDefaultProperties() {
     $properties = parent::getDefaultProperties() + [
         'vocab' => 'agent',
         'rdftype' => 'thing',
-      ] + parent::defineDefaultProperties()
-      + $this->defineDefaultBaseProperties();
+      ];
 
     return $properties;
   }

--- a/src/Plugin/WebformElement/WebformGetty.php
+++ b/src/Plugin/WebformElement/WebformGetty.php
@@ -31,15 +31,14 @@ class WebformGetty extends WebformCompositeBase {
     return [
       'vocab' => 'aat',
       'matchtype' => 'fuzzy',
-    ];
+    ] + parent::defineDefaultBaseProperties();
   }
 
   public function getDefaultProperties() {
     $properties = parent::getDefaultProperties() + [
         'vocab' => 'aat',
         'matchtype' => 'fuzzy',
-      ] + parent::defineDefaultProperties()
-      + $this->defineDefaultBaseProperties();
+      ];
 
     return $properties;
   }

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -33,15 +33,14 @@ class WebformLoC extends WebformCompositeBase {
     return [
       'vocab' => 'subjects',
       'rdftype' => 'FullName',
-    ];
+    ] + parent::defineDefaultBaseProperties();
   }
 
   public function getDefaultProperties() {
     $properties = parent::getDefaultProperties() + [
         'vocab' => 'subjects',
         'rdftype' => 'FullName',
-      ] + parent::defineDefaultProperties()
-      + $this->defineDefaultBaseProperties();
+      ];
 
     return $properties;
   }

--- a/src/Plugin/WebformElement/WebformMultiAgent.php
+++ b/src/Plugin/WebformElement/WebformMultiAgent.php
@@ -38,7 +38,7 @@ class WebformMultiAgent extends WebformCompositeBase {
       'vocab_corporate_name' => '',
       'rdftype_corporate_name' => '',
       'role_type' => '',
-    ];
+    ] + parent::defineDefaultBaseProperties();
   }
 
   public function getDefaultProperties() {
@@ -51,8 +51,7 @@ class WebformMultiAgent extends WebformCompositeBase {
         'vocab_corporate_name' => '',
         'rdftype_corporate_name' => '',
         'role_type' => '',
-      ]
-      + parent::defineDefaultProperties();
+      ];
 
     unset($properties['multiple__header']);
     return $properties;

--- a/src/Plugin/WebformElement/WebformNominatim.php
+++ b/src/Plugin/WebformElement/WebformNominatim.php
@@ -38,7 +38,7 @@ class WebformNominatim extends WebformLocationBase {
         'geolocation' => FALSE,
         'hidden' => FALSE,
         'map' => FALSE,
-      ] + $this->defineDefaultBaseProperties();
+      ];
   }
 
   /**


### PR DESCRIPTION
See #124 

Each webform element has some inherited base properties, we neglected on inheriting the right ones when overriding the defaults disabling because of the that a Access and also Advanced tab properties used to configured element instances in a webform

This pull should fix the issue and goes into RC3

@giancarlobi you want to update once its merged and @dmer @patdunlavey you want to test and see if all is working afterwards.