### PR TITLE
ISSUE-127 and ISSUE-128: adds snac + better draft session management when editing/cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 src/Tools/Iiif/IiifHelper.php
 .idea/webform_strawberryfield.iml
 src/.DS_Store
+.idea/runConfigurations/archipelago.xml

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=7.2",
+        "ext-json": "*",
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
         "strawberryfield/strawberryfield":"dev-1.0.0-RC2",

--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -163,6 +163,9 @@ class AuthAutocompleteController extends ControllerBase implements ContainerInje
     if (is_string($csrf_token)) {
       $request_base = $request->getSchemeAndHttpHost().':'.$request->getPort();
       $is_internal =  $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_ADDR'].':'.$_SERVER['SERVER_PORT'] == $request_base;
+      if (!$is_internal) {
+        $is_internal = $_SERVER['HTTP_HOST'] == $_SERVER['SERVER_NAME'];
+      }
     }
 
     if ($input) {
@@ -612,12 +615,12 @@ SPARQL;
 
     $jsondata = [];
     $results = [];
-    $jsondata = json_decode($body, TRUE);
+    $jsondata = json_decode($body, TRUE) ?? [];
     $json_error = json_last_error();
     if ($json_error == JSON_ERROR_NONE) {
       //WIKIdata will give is an success key will always return at least one, the query string
       if (count($jsondata) > 1) {
-        if (count($jsondata['result']) >= 1) {
+        if (isset($jsondata['result']) && is_array($jsondata['result']) && count($jsondata['result']) >= 1)  {
           foreach ($jsondata['result'] as $key => $item) {
             $desc = (isset($item['nametype'])) ? '(' . $item['nametype'] . ')' : NULL;
             $results[] = [

--- a/src/Controller/StrawberryRunnerModalController.php
+++ b/src/Controller/StrawberryRunnerModalController.php
@@ -138,17 +138,18 @@ class StrawberryRunnerModalController extends ControllerBase
       // In case we are editing an existing entity, this one gets the
       // Strawberryfield value
       $alldata = $source_entity->get($field_name)->getValue();
-      $fielddata['value'] = !empty($alldata) ? $alldata[$delta]['value']: "{}";
+      $fielddata['value'] = $alldata[$delta]['value'] ?? "{}";
       $entityid = $source_entity->id();
     }
 
-    $stored_value = (isset($fielddata['value']) && !empty($fielddata['value'])) ? $fielddata['value'] : "{}";
+    $stored_value = $fielddata['value'] ?? "{}";
 
     $data_defaults = [
       'strawberry_field_widget_state_id' => $widgetid,
       // Can't remember why, but seems useful to pass around
       'strawberry_field_widget_source_entity_uuid' => $source_uuid,
       'strawberry_field_widget_source_entity_id' => $entityid,
+      'strawberry_field_widget_autosave' => $entityid ? FALSE : TRUE,
       'strawberry_field_stored_values' => json_decode($stored_value,true)
     ];
 
@@ -247,7 +248,7 @@ class StrawberryRunnerModalController extends ControllerBase
         // We delete both, the session and the accumulated errors.
         /** @var \Drupal\Core\TempStore\PrivateTempStore $tempstore */
         $tempstore = \Drupal::service('tempstore.private')->get('archipel');
-        $tempstore->delete($clear_saved);
+        $tempstore->delete($clear_saved.'-draft');
         $tempstore->delete($clear_saved.'-errors');
         // Selector us built using the field name and the delta.
         $response->addCommand(new \Drupal\Core\Ajax\HtmlCommand('#' . $selector  .' > .fieldset-wrapper',

--- a/src/Element/WebformMesh.php
+++ b/src/Element/WebformMesh.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\webform_strawberryfield\Element;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Element\WebformCompositeBase;
+
+
+/**
+ * Provides a form element to reconciliate against Medical Subject Headings.
+ *
+ * @FormElement("webform_metadata_mesh")
+ */
+class WebformMesh extends WebformCompositeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $info =  parent::getInfo() + [
+        '#vocab' => 'descriptor',
+        '#matchtype' => 'startswith'
+      ];
+    return $info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCompositeElements(array $element) {
+    $elements = [];
+    $vocab = 'descriptor';
+    $matchtype = 'startswith';
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (isset($element['#matchtype'])) {
+      $matchtype = $element['#matchtype'];
+    }
+
+    $class = '\Drupal\webform_strawberryfield\Element\WebformMesh';
+    $elements['label'] = [
+      '#type' => 'textfield',
+      '#title' => t('MeSH @vocab Label',['@vocab' => $vocab]),
+      '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
+      '#autocomplete_route_parameters' => ['auth_type' => 'mesh', 'vocab' => $vocab, 'rdftype'=> $matchtype ,'count' => 10],
+      '#attributes' => [
+        'data-source-strawberry-autocomplete-key' => 'label',
+        'data-target-strawberry-autocomplete-key' => 'uri'
+      ],
+    ];
+
+    $elements['uri'] = [
+      '#type' => 'url',
+      '#title' => t('MeSH URL'),
+      '#attributes' => ['data-strawberry-autocomplete-value' => TRUE]
+    ];
+    $elements['label']['#process'][] =  [$class, 'processAutocomplete'];
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
+    // @Disclaimer: This function is the worst and deceiving. Keeping it here
+    // So i never make this error again. Because of
+    // \Drupal\webform\Plugin\WebformElement\WebformCompositeBase::prepareMultipleWrapper
+    // Basically, in case of having multiple elements :: processWebformComposite
+    // is *never* called because it actually converts the 'WebformComposite' element into a
+    // \Drupal\webform\Element\WebformMultiple calling ::processWebformMultiple element
+
+    $vocab = 'descriptor';
+    $matchtype = 'startswith';
+
+    $element = parent::processWebformComposite($element, $form_state, $complete_form);
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (isset($element['#matchtype'])) {
+      $matchtype = $element['#matchtype'];
+    }
+
+    $element['label']["#autocomplete_route_parameters"] =
+      ['auth_type' => 'mesh', 'vocab' => $vocab, 'rdftype'=> $matchtype ,'count' => 10];
+
+    return $element;
+  }
+
+  /**
+   * @param array $element
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * @param array $complete_form
+   *
+   * @return array
+   */
+  public static function processAutocomplete(&$element, FormStateInterface $form_state, &$complete_form) {
+    $element = parent::processAutocomplete($element, $form_state, $complete_form);
+    $element['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.metadataauth.autocomplete';
+    $element['#attached']['drupalSettings'] = [
+        'webform_strawberryfield_autocomplete' => [],
+      ];
+
+    $element['#attributes']['data-strawberry-autocomplete'] = 'mesh';
+    return $element;
+  }
+
+}

--- a/src/Element/WebformSnac.php
+++ b/src/Element/WebformSnac.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\webform_strawberryfield\Element;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Element\WebformCompositeBase;
+
+
+/**
+ * Provides a webform element for a Snac element.
+ *
+ * @FormElement("webform_metadata_snac")
+ */
+class WebformSnac extends WebformCompositeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    // #rdftype one of person, corporateBody, family, thing will kick in any
+    $info =  parent::getInfo() + [
+      '#vocab' => 'Constellation',
+      '#rdftype' => 'thing'
+    ];
+    return $info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCompositeElements(array $element) {
+
+    $elements = [];
+    $vocab = 'Constellation';
+    $rdftype = 'thing';
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+      $rdftype = trim($element['#rdftype']);
+    }
+
+    $class = '\Drupal\webform_strawberryfield\Element\WebformLoC';
+    $elements['label'] = [
+      '#type' => 'textfield',
+      '#title' => t('Label'),
+      '#autocomplete_route_name' => 'webform_strawberryfield.auth_autocomplete',
+      '#autocomplete_route_parameters' => ['auth_type' => 'snac', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10],
+      '#attributes' => [
+        'data-source-strawberry-autocomplete-key' => 'label',
+        'data-target-strawberry-autocomplete-key' => 'uri'
+      ],
+
+    ];
+    $elements['uri'] = [
+      '#type' => 'url',
+      '#title' => t('Snac URL'),
+      '#attributes' => ['data-strawberry-autocomplete-value' => TRUE]
+    ];
+    $elements['label']['#process'][] =  [$class, 'processAutocomplete'];
+    return $elements;
+  }
+
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
+    // @Disclaimer: This function is the worst and deceiving. Keeping it here
+    // So i never make this error again. Because of
+    // \Drupal\webform\Plugin\WebformElement\WebformCompositeBase::prepareMultipleWrapper
+    // Basically, in case of having multiple elements :: processWebformComposite
+    // is *never* called because it actually converts the 'WebformComposite' element into a
+    // \Drupal\webform\Element\WebformMultiple calling ::processWebformMultiple element
+    // So basically whatever i do here gets skipped if multiple elements are allowed.
+    // Solution is acting here instead:
+    // \Drupal\webform_strawberryfield\Plugin\WebformElement\WebformLoC::prepareMultipleWrapper
+    $vocab = 'Constellation';
+    $rdftype = 'thing';
+
+    $element = parent::processWebformComposite($element, $form_state, $complete_form);
+    if (isset($element['#vocab'])) {
+      $vocab = $element['#vocab'];
+    }
+    if (($vocab == 'rdftype') && isset($element['#rdftype'])) {
+      $rdftype = trim($element['#rdftype']);
+    }
+    $element['label']["#autocomplete_route_parameters"] =
+      ['auth_type' => 'snac', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
+
+    return $element;
+  }
+
+  /**
+   * @param array $element
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * @param array $complete_form
+   *
+   * @return array
+   */
+  public static function processAutocomplete(&$element, FormStateInterface $form_state, &$complete_form) {
+    $element = parent::processAutocomplete($element, $form_state, $complete_form);
+    $element['#attached']['library'][] = 'webform_strawberryfield/webform_strawberryfield.metadataauth.autocomplete';
+    $element['#attached']['drupalSettings'] = [
+      'webform_strawberryfield_autocomplete' => [],
+    ];
+
+    $element['#attributes']['data-strawberry-autocomplete'] = 'Snac';
+    return $element;
+  }
+
+
+}

--- a/src/EventSubscriber/WebformStrawberryfieldDeleteTmpStorage.php
+++ b/src/EventSubscriber/WebformStrawberryfieldDeleteTmpStorage.php
@@ -111,8 +111,13 @@ class WebformStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface
       foreach ($field->getValue() as $delta => $value) {
         $keyid = $this->getTempStoreKeyName($fieldname, $delta, '');
         $tempstore->delete($keyid);
-        // Delete also any cached errors
-        $tempstore->delete($keyid.'-errors');
+        // Delete also any cached errors and drafts if the autosave session
+        // Generated this ADO. If not (e.g Clone we will have marked that
+        // ADO's UUID as not autosave so we do not delete another ongoing session
+        if ($this->tempStoreFactory->get('archipel_autosave')->get($entity->uuid())) {
+          $tempstore->delete($keyid . '-errors');
+          $tempstore->delete($keyid . '-draft');
+        }
       }
     }
 

--- a/src/Plugin/WebformElement/WebformMesh.php
+++ b/src/Plugin/WebformElement/WebformMesh.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 12/2/18
+ * Time: 5:17 PM
+ */
+
+namespace Drupal\webform_strawberryfield\Plugin\WebformElement;
+
+use Drupal\Core\Site\Settings;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Provides an 'LoC Heading' element.
+ *
+ * @WebformElement(
+ *   id = "webform_metadata_mesh",
+ *   label = @Translation("PubMed MeSH Suggest"),
+ *   description = @Translation("Provides a form element to reconciliate against Medical Subject Headings (MeSH) RDF API."),
+ *   category = @Translation("Composite elements"),
+ *   multiline = TRUE,
+ *   composite = TRUE,
+ *   states_wrapper = TRUE,
+ * )
+ */
+class WebformMesh extends WebformCompositeBase {
+
+
+  protected function defineDefaultBaseProperties() {
+    return [
+        'vocab' => 'descriptor',
+        'matchtype' => 'startswith',
+      ] + parent::defineDefaultBaseProperties();
+  }
+
+  public function getDefaultProperties() {
+    $properties = parent::getDefaultProperties() + [
+        'vocab' => 'descriptor',
+        'matchtype' => 'startswith',
+      ];
+
+    return $properties;
+  }
+
+
+
+  public function prepare(
+    array &$element,
+    WebformSubmissionInterface $webform_submission = NULL
+  ) {
+
+    // @TODO explore this method to act on submitted data v/s element behavior
+  }
+
+  /**
+   * Set multiple element wrapper.
+   *
+   * @param array $element
+   *   An element.
+   */
+  protected function prepareMultipleWrapper(array &$element) {
+
+    parent::prepareMultipleWrapper($element);
+
+    // Finally!
+    // This is the last chance we have to affect the render array
+    // This is where the original element type is also
+    // swapped by webform_multiple
+    // breaking all our #process callbacks.
+    $matchtype = trim($this->getElementProperty($element, 'matchtype'));
+    $matchtype = $matchtype?: $this->getDefaultProperty('matchtype');
+    $vocab = $this->getElementProperty($element, 'vocab');
+    $vocab = $vocab ?:  $this->getDefaultProperty('vocab');
+    if (isset($element['#element']['#webform_composite_elements']['label'])) {
+      $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'mesh',
+          'vocab' => $vocab,
+          'rdftype' => $matchtype,
+          'count' => 10
+        ];
+    }
+    // For some reason i can not understand, when multiples are using
+    // Tables, the #webform_composite_elements -> 'label' is not used...
+    if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {
+      $element['#element']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'mesh',
+          'vocab' => $vocab,
+          'rdftype' => $matchtype,
+          'matchtype' => 'startswith',
+          'count' => 10
+        ];
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginLabel() {
+    return $this->elementManager->isExcluded('webform_metadata_mesh') ? $this->t('Medical Subject Heading MeSH') : parent::getPluginLabel();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatHtmlItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    return $this->formatTextItemValue($element, $webform_submission, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    $value = $this->getValue($element, $webform_submission, $options);
+
+    $lines = [];
+    if (!empty($value['uri'])) {
+      $lines[] = $value['uri'];
+    }
+
+    if (!empty($value['label'])) {
+      $lines[] = $value['label'];
+    }
+    return $lines;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['composite']['vocab'] = [
+      '#type' => 'select',
+      '#options' => [
+        'descriptor' => 'Medical Subject Headings Descriptor (Subject Headings) API',
+        'term' => 'Medical Subject Headings Term API',
+      ],
+      '#title' => $this->t("What MeSH Autocomplete API Type to use."),
+      '#description' =>  $this->t('See <a href="https://id.nlm.nih.gov/mesh/swagger/ui#/">MeSH Subject HeadingsAPI</a>'),
+
+    ];
+    $form['composite']['matchtype'] = [
+      '#type' => 'select',
+      '#options' => [
+        'exact' => 'Exact, based on recommended Label. Will give you a single result or none.',
+        'startswith' => 'Label Starts with.',
+        'contains' => 'Label Contains.',
+      ],
+      '#title' => $this->t("What type of Match Query to perform"),
+      '#description' => $this->t('All match types return the same number of results. Exact matches only against the prefered label of the query.'),
+    ];
+    return $form;
+  }
+
+}

--- a/src/Plugin/WebformElement/WebformSnac.php
+++ b/src/Plugin/WebformElement/WebformSnac.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 12/2/18
+ * Time: 5:17 PM
+ */
+
+namespace Drupal\webform_strawberryfield\Plugin\WebformElement;
+
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Provides an 'LoC Heading' element.
+ *
+ * @WebformElement(
+ *   id = "webform_metadata_snac",
+ *   label = @Translation("SNAC Constellation Linked Open Data"),
+ *   description = @Translation("Provides a form element to reconciliate against Snac Entity Type LoD Sources."),
+ *   category = @Translation("Composite elements"),
+ *   multiline = TRUE,
+ *   composite = TRUE,
+ *   states_wrapper = TRUE,
+ * )
+ */
+class WebformSnac extends WebformCompositeBase {
+
+
+  protected function defineDefaultBaseProperties() {
+    return [
+      'vocab' => 'Constellation',
+      'rdftype' => 'thing',
+    ] + parent::defineDefaultBaseProperties();
+  }
+
+  public function getDefaultProperties() {
+    $properties = parent::getDefaultProperties() + [
+        'vocab' => 'Constellation',
+        'rdftype' => 'thing',
+      ];
+
+    return $properties;
+  }
+
+
+
+  public function prepare(
+    array &$element,
+    WebformSubmissionInterface $webform_submission = NULL
+  ) {
+
+    // @TODO explore this method to act on submitted data v/s element behavior
+  }
+
+  /**
+   * Set multiple element wrapper.
+   *
+   * @param array $element
+   *   An element.
+   */
+  protected function prepareMultipleWrapper(array &$element) {
+
+    parent::prepareMultipleWrapper($element);
+
+    // Finally!
+    // This is the last chance we have to affect the render array
+    // This is where the original element type is also
+    // swapped by webform_multiple
+    // breaking all our #process callbacks.
+    $vocab = 'Constellation';
+    $rdftype = 'thing';
+    $vocab = $this->getElementProperty($element, 'vocab');
+    $vocab = $vocab ?:  $this->getDefaultProperty($vocab);
+    if ($vocab == 'rdftype') {
+      $rdftype = trim($this->getElementProperty($element, 'rdftype'));
+    }
+
+    $rdftype = $rdftype ?: $this->getDefaultProperty($rdftype);
+    // This seems to have been an old Webform module variation
+    // Keeping it here until sure its not gone for good
+    if (isset($element['#element']['#webform_composite_elements']['label'])) {
+      $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'snac',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+    // For some reason i can not understand, when multiples are using
+    // Tables, the #webform_composite_elements -> 'label' is not used...
+    if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {
+      $element['#element']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'snac',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginLabel() {
+    return $this->elementManager->isExcluded('webform_metadata_snac') ? $this->t('SNAC Constellation Terms') : parent::getPluginLabel();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatHtmlItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    return $this->formatTextItemValue($element, $webform_submission, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    $value = $this->getValue($element, $webform_submission, $options);
+
+    $lines = [];
+    if (!empty($value['uri'])) {
+      $lines[] = $value['uri'];
+    }
+
+    if (!empty($value['label'])) {
+      $lines[] = $value['label'];
+    }
+    return $lines;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['composite']['vocab'] = [
+      '#type' => 'select',
+      '#options' => [
+        'Constellation' => 'All Constellation Entity Types',
+        'rdftype' => 'By specific Constellation Entity Types',
+      ],
+      '#title' => $this->t("What SNAC query type to use."),
+      '#description' => $this->t('Specific Entity Types can be: person, corporateBody or family'),
+    ];
+    // Not sure if this has a sub authority and how that works/if suggest
+    $form['composite']['rdftype'] = [
+      '#type' => 'select',
+      '#options' => [
+        'person' => 'person',
+        'corporateBody' => 'corporateBody',
+        'family' => 'family',
+      ],
+      '#title' => $this->t("What SNAC Entity type to use as filter"),
+      '#description' => $this->t('Can be one of: person, corporateBody or family'),
+      '#default_value' => 'person',
+      '#states' => [
+        'visible' => [
+          ':input[name="properties[vocab]"]' => ['value' => 'rdftype'],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+}

--- a/src/Plugin/WebformHandler/strawberryFieldharvester.php
+++ b/src/Plugin/WebformHandler/strawberryFieldharvester.php
@@ -9,7 +9,7 @@ use Drupal\webform\Plugin\WebformElement\WebformManagedFileBase;
 use Drupal\webform\Plugin\WebformElementEntityReferenceInterface;
 use Drupal\webform\Plugin\WebformHandlerBase;
 use Drupal\webform\WebformInterface;
-use Drupal\webform\webformSubmissionInterface;
+use Drupal\webform\WebformSubmissionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;


### PR DESCRIPTION
# What?

See #127 and #128

- Adds new webform element for SNAC https://snaccooperative.org
- Deeply reforms Draft Saving. On Object Edit open Drafts are untouched. On cloning (and any Code base Entity Duplication) Drafts are not used so you do not end with legacy data. 
- "you have an unfinished" session message now is part of the Widget Title (to avoid aggressive themes to try to show that as a message on every Form/webform submit (even hidden operations like changing the Type of Agent triggered this on the Bootstrap Barrio theme)
