### PR TITLE
ISSUE-153: Solr driven entity autocomplete can not use match operator

### DIFF
--- a/src/Element/WebformPanoramaTour.php
+++ b/src/Element/WebformPanoramaTour.php
@@ -1327,7 +1327,6 @@ class WebformPanoramaTour extends WebformCompositeBase {
         // Means it was something inside the button
       }
       else {
-        error_log('Clear our redundant values');
         $form_state->unsetValue([$element['#name'], 'scene']);
         $form_state->unsetValue([$element['#name'], 'hotspots']);
         $form_state->unsetValue([$element['#name'], 'hotspots_temp']);

--- a/src/Plugin/EntityReferenceSelection/ViewsSolrSelection.php
+++ b/src/Plugin/EntityReferenceSelection/ViewsSolrSelection.php
@@ -261,6 +261,12 @@ class ViewsSolrSelection extends SelectionPluginBase implements ContainerFactory
     $limit = 0,
     $ids = NULL
   ) {
+    // @See https://github.com/esmero/webform_strawberryfield/issues/153
+    // May 2023,  match_operator can not be used with Solr.
+    // We will keep it around to make the classes match but is unused
+    // When using Solr we will always get native match based on the Field
+    // type.
+
     $view_name = $this->getConfiguration()['view']['view_name'];
     $display_name = $this->getConfiguration()['view']['display_name'];
 

--- a/src/Plugin/views/display/EntityReference.php
+++ b/src/Plugin/views/display/EntityReference.php
@@ -182,12 +182,6 @@ class EntityReference extends DisplayPluginBase {
       // See if we need to use some escape mechanism from here
       // @see \Drupal\search_api_solr\Utility\Utility
       $value = $options['match_solr'];
-      if ($options['match_operator_solr'] !== '=') {
-        $value = $value . '%';
-        if ($options['match_operator_solr'] != 'STARTS_WITH') {
-          $value = '%' . $value;
-        }
-      }
 
       // Multiple search fields are OR'd together.
       $match_condition_group = $search_api_query->createConditionGroup('OR');


### PR DESCRIPTION
See #153 
This removes it and allows the actual field/type of field searched for to deal with "contains". There is no "starts" with in Solr/Lucene but an exact match will happen if the field is a non-full-text string.

Also note for @alliomeria we have been doing this a bit wrong! The actual searched fields are part of the Options on the top, the filter we add is basically "useless". It always uses the configured "fields", the "filters" are used as additional to the the autocomplete match. I hate Drupal sometimes!

![image](https://github.com/esmero/webform_strawberryfield/assets/6946023/bbd22464-f8d6-49ed-8055-49369c245f96)
