### PR TITLE
Update for MeSH Autocomplete

### DIFF
--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -925,26 +925,27 @@ SPARQL;
     $results = [];
     $jsondata = json_decode($body, TRUE);
     $json_error = json_last_error();
-      if ($json_error == JSON_ERROR_NONE) {
+    if ($json_error == JSON_ERROR_NONE) {
       if (count($jsondata) > 0) {
-      foreach ($jsondata as $entry) {
-      if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
-        array_unshift($results, [
-          'value' => $entry['resource'],
-          'label' => $entry['label'],
-        ]);
-      } else {
-        $results[] = [
-          'value' => $entry['resource'],
-          'label' => $entry['label'],
-        ];
+        foreach ($jsondata as $entry) {
+          if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
+            array_unshift($results, [
+            'value' => $entry['resource'],
+            'label' => $entry['label'],
+            ]);
+          } 
+          else {
+            $results[] = [
+            'value' => $entry['resource'],
+            'label' => $entry['label'],
+            ];
+          }
+        }
       }
-    }
-  }
       else {
         $results[] = [
-          'value' => NULL,
-          'label' => "Sorry no match from MeSH for {$vocab}",
+        'value' => NULL,
+        'label' => "Sorry no match from MeSH for {$vocab}",
         ];
       }
       return $results;

--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -916,24 +916,31 @@ SPARQL;
       return $results;
     }
 
-    $input = rawurlencode($input);
-    $urlindex = "/mesh/lookup/{$vocab}?label=" . $input .'&limit=10&match=' . $rdftype;
-    $baseurl = 'https://id.nlm.nih.gov';
-    $remoteUrl = $baseurl . $urlindex;
-    $options['headers'] = ['Accept' => 'application/json'];
-    $body = $this->getRemoteJsonData($remoteUrl, $options);
-    $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
-      if (count($jsondata) > 1) {
-        foreach ($jsondata as $entry) {
-          $results[] = [
-            'value' => $entry['resource'],
-            'label' => $entry['label'],
-          ];
-        }
+$input_encoded = rawurlencode($input);
+$urlindex = "/mesh/lookup/{$vocab}?label=" . $input_encoded .'&limit=10&match=' . $rdftype;
+$baseurl = 'https://id.nlm.nih.gov';
+$remoteUrl = $baseurl . $urlindex;
+$options['headers'] = ['Accept' => 'application/json'];
+$body = $this->getRemoteJsonData($remoteUrl, $options);
+$results = [];
+$jsondata = json_decode($body, TRUE);
+$json_error = json_last_error();
+if ($json_error == JSON_ERROR_NONE) {
+  if (count($jsondata) > 0) {
+    foreach ($jsondata as $entry) {
+      if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
+        array_unshift($results, [
+          'value' => $entry['resource'],
+          'label' => $entry['label'],
+        ]);
+      } else {
+        $results[] = [
+          'value' => $entry['resource'],
+          'label' => $entry['label'],
+        ];
       }
+    }
+  }
       else {
         $results[] = [
           'value' => NULL,

--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -916,18 +916,18 @@ SPARQL;
       return $results;
     }
 
-$input_encoded = rawurlencode($input);
-$urlindex = "/mesh/lookup/{$vocab}?label=" . $input_encoded .'&limit=10&match=' . $rdftype;
-$baseurl = 'https://id.nlm.nih.gov';
-$remoteUrl = $baseurl . $urlindex;
-$options['headers'] = ['Accept' => 'application/json'];
-$body = $this->getRemoteJsonData($remoteUrl, $options);
-$results = [];
-$jsondata = json_decode($body, TRUE);
-$json_error = json_last_error();
-if ($json_error == JSON_ERROR_NONE) {
-  if (count($jsondata) > 0) {
-    foreach ($jsondata as $entry) {
+    $input_encoded = rawurlencode($input);
+    $urlindex = "/mesh/lookup/{$vocab}?label=" . $input_encoded .'&limit=10&match=' . $rdftype;
+    $baseurl = 'https://id.nlm.nih.gov';
+    $remoteUrl = $baseurl . $urlindex;
+    $options['headers'] = ['Accept' => 'application/json'];
+    $body = $this->getRemoteJsonData($remoteUrl, $options);
+    $results = [];
+    $jsondata = json_decode($body, TRUE);
+    $json_error = json_last_error();
+      if ($json_error == JSON_ERROR_NONE) {
+      if (count($jsondata) > 0) {
+      foreach ($jsondata as $entry) {
       if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
         array_unshift($results, [
           'value' => $entry['resource'],

--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -930,22 +930,22 @@ SPARQL;
         foreach ($jsondata as $entry) {
           if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
             array_unshift($results, [
-            'value' => $entry['resource'],
-            'label' => $entry['label'],
+              'value' => $entry['resource'],
+              'label' => $entry['label'],
             ]);
           } 
           else {
             $results[] = [
-            'value' => $entry['resource'],
-            'label' => $entry['label'],
+              'value' => $entry['resource'],
+              'label' => $entry['label'],
             ];
           }
         }
       }
       else {
         $results[] = [
-        'value' => NULL,
-        'label' => "Sorry no match from MeSH for {$vocab}",
+          'value' => NULL,
+          'label' => "Sorry no match from MeSH for {$vocab}",
         ];
       }
       return $results;


### PR DESCRIPTION
For https://github.com/esmero/ami/issues/185, to complement  https://github.com/esmero/ami/pull/186

Update logic for processing MeSH queries:
- for count > 0 (instead of 1)
- make use of array_unshift to better sort and select results that more closely match original query

Coded live by @DiegoPino and shared with @alliomeria for local testing. Thank you @DiegoPino!