### PR TITLE
ISSUE-177: LoD Autocomplete Fixes and Improvements

### DIFF
--- a/src/Plugin/WebformElement/WebformEuropeana.php
+++ b/src/Plugin/WebformElement/WebformEuropeana.php
@@ -84,6 +84,15 @@ class WebformEuropeana extends WebformCompositeBase {
           'count' => 10
         ];
     }
+   elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+     $element['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+       [
+         'auth_type' => 'europeana',
+         'vocab' => $vocab,
+         'rdftype' => $rdftype,
+         'count' => 10
+       ];
+   }
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...
     if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {

--- a/src/Plugin/WebformElement/WebformGetty.php
+++ b/src/Plugin/WebformElement/WebformGetty.php
@@ -78,6 +78,16 @@ class WebformGetty extends WebformCompositeBase {
           'count' => 10
         ];
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      $element['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'getty',
+          'vocab' => $vocab,
+          'rdftype' => $matchtype,
+          'count' => 10
+        ];
+    }
+
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...
     if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -90,6 +90,15 @@ class WebformLoC extends WebformCompositeBase {
           'count' => 10
         ];
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      $element['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'loc',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...
     if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {

--- a/src/Plugin/WebformElement/WebformLoDfromCSV.php
+++ b/src/Plugin/WebformElement/WebformLoDfromCSV.php
@@ -41,6 +41,7 @@ class WebformLoDfromCSV extends WebformCompositeBase {
         'autocomplete_match' => 3,
         'autocomplete_label_header' => 'label',
         'autocomplete_url_header' => 'url',
+        'autocomplete_desc_headers' => '',
         'autocomplete_match_operator' => 'CONTAINS',
       ] + parent::defineDefaultProperties()
       + $this->defineDefaultMultipleProperties();
@@ -62,6 +63,16 @@ class WebformLoDfromCSV extends WebformCompositeBase {
 
     if (isset($element['#webform_key'])) {
       $element['#autocomplete_route_name'] = 'webform_strawberryfield.rowsbylabel.autocomplete';
+      $desc = $element['#autocomplete_desc_headers'] ?? $properties['autocomplete_desc_headers'];
+      if (is_string($desc) && strlen(trim($desc)) > 0 ) {
+        $desc = explode(',', $desc);
+        $desc = array_slice($desc, 0, 2);
+        $desc = array_map('trim', $desc);
+        $desc = implode(',', $desc);
+      }
+      else {
+        $desc = '';
+      }
       $element['#autocomplete_route_parameters'] = [
         'node' =>  $element['#autocomplete_items'],
         'label_header' => $element['#autocomplete_label_header'] ?? $properties['autocomplete_label_header'],
@@ -69,6 +80,7 @@ class WebformLoDfromCSV extends WebformCompositeBase {
         'match' => $element['#autocomplete_match_operator'] ?? $properties['autocomplete_match_operator'],
         'limit' => $element['#autocomplete_limit'] ?? $properties['autocomplete_limit'],
         'min' => $element['#autocomplete_match'] ?? $properties['autocomplete_match'],
+        'desc_headers' =>  $desc,
       ];
     }
   }
@@ -160,6 +172,11 @@ class WebformLoDfromCSV extends WebformCompositeBase {
       '#type' => 'textfield',
       '#title' => $this->t('The CSV column(header name) that will be used for the URL value'),
       '#required' => TRUE,
+    ];
+    $form['autocomplete']['autocomplete_desc_headers'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('The CSV columns(header names), separated by a comma, that will be used for additional context/description. Leave empty if not used. It has a limited of 2 headers. Any extra ones will be ignored.'),
+      '#required' => FALSE,
     ];
     $form['autocomplete']['autocomplete_limit'] = [
       '#type' => 'number',

--- a/src/Plugin/WebformElement/WebformLoDfromCSV.php
+++ b/src/Plugin/WebformElement/WebformLoDfromCSV.php
@@ -85,6 +85,11 @@ class WebformLoDfromCSV extends WebformCompositeBase {
       $element['#element']['#webform_composite_elements']['label']['#autocomplete_route_name'] = $autocomplete_route;
       $element['#element']['#webform_composite_elements']['label']['#autocomplete_route_parameters'] = $autocomplete_route_params;
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      // Not a multiple one. So assign the Autocomplete route directly to the composite children.
+      $element['#webform_composite_elements']['label']['#autocomplete_route_name'] = $autocomplete_route;
+      $element['#webform_composite_elements']['label']['#autocomplete_route_parameters'] = $autocomplete_route_params;
+    }
 
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...

--- a/src/Plugin/WebformElement/WebformLoDfromCSV.php
+++ b/src/Plugin/WebformElement/WebformLoDfromCSV.php
@@ -66,6 +66,9 @@ class WebformLoDfromCSV extends WebformCompositeBase {
         'node' =>  $element['#autocomplete_items'],
         'label_header' => $element['#autocomplete_label_header'] ?? $properties['autocomplete_label_header'],
         'url_header' => $element['#autocomplete_url_header'] ?? $properties['autocomplete_url_header'],
+        'match' => $element['#autocomplete_match_operator'] ?? $properties['autocomplete_match_operator'],
+        'limit' => $element['#autocomplete_limit'] ?? $properties['autocomplete_limit'],
+        'min' => $element['#autocomplete_match'] ?? $properties['autocomplete_match'],
       ];
     }
   }

--- a/src/Plugin/WebformElement/WebformLoDfromOptions.php
+++ b/src/Plugin/WebformElement/WebformLoDfromOptions.php
@@ -80,6 +80,11 @@ class WebformLoDfromOptions extends WebformCompositeBase {
       $element['#element']['#webform_composite_elements']['label']['#autocomplete_route_name'] = $autocomplete_route;
       $element['#element']['#webform_composite_elements']['label']['#autocomplete_route_parameters'] = $autocomplete_route_params;
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      // Not a multiple one. So assign the Autocomplete route directly to the composite children.
+      $element['#webform_composite_elements']['label']['#autocomplete_route_name'] = $autocomplete_route;
+      $element['#webform_composite_elements']['label']['#autocomplete_route_parameters'] = $autocomplete_route_params;
+    }
 
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...

--- a/src/Plugin/WebformElement/WebformMesh.php
+++ b/src/Plugin/WebformElement/WebformMesh.php
@@ -84,6 +84,15 @@ class WebformMesh extends WebformCompositeBase {
           'count' => 10
         ];
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      $element['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'mesh',
+          'vocab' => $vocab,
+          'rdftype' => $matchtype,
+          'count' => 10
+        ];
+    }
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...
     if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {

--- a/src/Plugin/WebformElement/WebformSnac.php
+++ b/src/Plugin/WebformElement/WebformSnac.php
@@ -90,6 +90,15 @@ class WebformSnac extends WebformCompositeBase {
           'count' => 10
         ];
     }
+    elseif (isset($element['#webform_multiple']) && $element['#webform_multiple'] == FALSE && isset($element['#webform_composite_elements']['label'])) {
+      $element['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'snac',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
     // For some reason i can not understand, when multiples are using
     // Tables, the #webform_composite_elements -> 'label' is not used...
     if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -60,7 +60,7 @@ webform_strawberryfield.element.autocomplete:
     _entity_access: 'webform.submission_create'
 
 webform_strawberryfield.rowsbylabel.autocomplete:
-  path: '/webform_strawberry/csv_autocomplete/{node}/{label_header}/{url_header}/{match}/{limit}/{min}'
+  path: '/webform_strawberry/csv_autocomplete/{node}/{label_header}/{url_header}/{match}/{limit}/{min}/{desc_headers}'
   options:
     parameters:
       node:
@@ -73,6 +73,7 @@ webform_strawberryfield.rowsbylabel.autocomplete:
     match: 'STARTS_WITH'
     limit: 10
     min: 2
+    desc_headers: ''
     _controller: '\Drupal\webform_strawberryfield\Controller\RowAutocompleteController::handleAutocomplete'
     _format: json
   requirements:

--- a/webform_strawberryfield.routing.yml
+++ b/webform_strawberryfield.routing.yml
@@ -60,7 +60,7 @@ webform_strawberryfield.element.autocomplete:
     _entity_access: 'webform.submission_create'
 
 webform_strawberryfield.rowsbylabel.autocomplete:
-  path: '/webform_strawberry/csv_autocomplete/{node}/{label_header}/{url_header}'
+  path: '/webform_strawberry/csv_autocomplete/{node}/{label_header}/{url_header}/{match}/{limit}/{min}'
   options:
     parameters:
       node:
@@ -70,6 +70,9 @@ webform_strawberryfield.rowsbylabel.autocomplete:
   defaults:
     label_header: 'label'
     url_header: 'url'
+    match: 'STARTS_WITH'
+    limit: 10
+    min: 2
     _controller: '\Drupal\webform_strawberryfield\Controller\RowAutocompleteController::handleAutocomplete'
     _format: json
   requirements:


### PR DESCRIPTION
See #177 
@livsolis this is WIP. Will keep updating this list as we progress

- First pass of fixes @alliomeria. I tested with LoD From CSV and then cloned code. So ... someone (me too?) needs to test with the other ones. I feel confident about my code but would not hurt to double check all (or some random) LoD autocomplete elements for functionality when limited to 1. But honestly, up to you how we test this.
- Second pass. Contains v/s Starts with are respected. Also Limit and also how many characters (spaces are trimmed) kick off autocomplete
- Third pass. You can use also now extra columns (max 2) for additional context
- Fourth Pass. (old bug!) We don't allow Drupal to cache the autocompletes during interactions which would lead in the past, after a selection was made, to have on the same autocomplete next time the URL coming up instead of the label.