### PR TITLE
ISSUE-138: Metadata Date element Conditional Selector check fix

### DIFF
--- a/src/Element/WebformEdftDate.php
+++ b/src/Element/WebformEdftDate.php
@@ -33,16 +33,22 @@ class WebformEdftDate extends Textfield {
    * Validates EDTF
    */
   public static function validateMetadataDates(&$element, FormStateInterface $form_state, &$complete_form) {
-    $validator = EdtfFactory::newValidator();
-    if (!$validator->isValidEdtf($element['#value'])) {
-      $form_state->setError($element,
-        t('The extended date time format string for the @name field is invalid.',
-          [
-            '@name' => $element['#title'],
-          ]));
+    // Don't validate empties.
+    if (empty($element['#value'])) {
+      $element['#validated'] = TRUE;
     }
     else {
-      $element['#validated'] = TRUE;
+      $validator = EdtfFactory::newValidator();
+      if (!$validator->isValidEdtf($element['#value'])) {
+        $form_state->setError($element,
+          t('The extended date time format string for the @name field is invalid.',
+            [
+              '@name' => $element['#title'],
+            ]));
+      }
+      else {
+        $element['#validated'] = TRUE;
+      }
     }
   }
 }

--- a/src/Plugin/WebformElement/MetadataDateBase.php
+++ b/src/Plugin/WebformElement/MetadataDateBase.php
@@ -14,6 +14,7 @@ use Drupal\webform\Element\WebformMessage as WebformMessageElement;
 use Drupal\webform\Plugin\WebformElementBase;
 use Drupal\webform\Utility\WebformArrayHelper;
 use Drupal\webform\Utility\WebformDateHelper;
+use Drupal\webform\WebformSubmissionConditionsValidator;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform\WebformInterface;
 
@@ -506,4 +507,66 @@ abstract class MetadataDateBase extends WebformElementBase {
     return $date_formatter->format($timestamp ?: time(), 'custom', $custom_format);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getElementSelectorInputValue($selector, $trigger, array $element, WebformSubmissionInterface $webform_submission) {
+    $input_name = WebformSubmissionConditionsValidator::getSelectorInputName($selector);
+    // Multivalued ones will have a different structure:
+    //   e.g. date_webform_key[items][0][_item_][date_type]
+    // Single Valued will be in the form of
+    //   e.g.  date_webform_key[date_type]
+    // Which if not processed correctly will give us as $composite_key items
+    $delta = NULL;
+    $composite_key = NULL;
+    if ($this->hasMultipleValues($element) === FALSE) {
+      // If not multiple, this is faster.
+      $composite_key = WebformSubmissionConditionsValidator::getInputNameAsArray($input_name, 1);
+    }
+    else {
+      // Multivalued, so we have potentially items, delta and _item_
+      $allkeys = WebformSubmissionConditionsValidator::getInputNameAsArray($input_name);
+      if (is_array($allkeys)) {
+        if (count($allkeys) <= 1) {
+          // Means we got either the top element or nothing.
+          return NULL;
+        }
+        else {
+          // Remove the element webform key
+          array_shift($allkeys);
+          // Reorder so we can fetch by index.
+          $allkeys = array_values(array_diff($allkeys, ['items', '_item_']));
+          // Now we need to have max two keys, a delta + composite key or this won't work
+          $composite_key = count($allkeys) == 2 ? $allkeys[1] : NULL;
+          $delta = count($allkeys) == 2 ? (is_numeric($allkeys[0]) ? (integer) ($allkeys[0]) : NULL) : NULL;
+        }
+      }
+      else {
+        // We got a string. Means also it will only match the top
+        // This will lead to an array value, so bail out.
+        return NULL;
+      }
+    }
+    if ($composite_key) {
+      $options =  ['composite_key' => $composite_key];
+      if ($delta !== NULL) {
+        $options['delta'] = $delta;
+      }
+      $raw = $this->getRawValue($element, $webform_submission, $options);
+      if (empty($raw)) {
+        $raw = NULL;
+      }
+      elseif (is_array($raw)) {
+        $raw = $raw[0] ?? NULL;
+        if ($raw!== NULL && !is_scalar($raw)) {
+          $raw = NULL;
+        }
+      }
+      // last pass. Never, at least for this element, return an Array.
+      return !is_array($raw) ? $raw : NULL;
+    }
+    else {
+      return NULL;
+    }
+  }
 }

--- a/src/Plugin/WebformElement/WebformMetadataDate.php
+++ b/src/Plugin/WebformElement/WebformMetadataDate.php
@@ -402,7 +402,6 @@ class WebformMetadataDate extends MetadataDateBase {
         $newvalue = $value;
       }
     }
-    error_log(print_r($newvalue, true));
     $webform_submission->setElementData($key,$newvalue);
   }
 }


### PR DESCRIPTION
See #138 

@patdunlavey your original ISSUE + Pull never got merged bc it was closed and not reopened afterwards. Old one (2022?) Sorry. 

This logic is similar (maybe a bit more over-reactive too) to yours with a few small changes to act quicker if the element is not multi valued.

Also, this adds a bug fix introduced by me on the last release/new simplified EDTF element. Never validate if empty. 

Note from @alliomeria:

- Without this fix you can avoid the errors if the element is like this :
```YAML
date_other_edtf:
    '#type': metadata_date
    '#title': 'Date Other'
    '#showfreeformalways': true
    '#edtf_validateme': true
    '#date_date_format': ''
```
by adding
```
'#states_clear': false
```

And avoid complete AJAX failure but making sure you have at the Drupal level at least on Error handler ("none" will permeate warnings into AJAX and break the form)