### PR TITLE
ISSUE-210: Fixes Core Webform elements that blindly "trim" on non strings

### DIFF
--- a/src/ElementHelper.php
+++ b/src/ElementHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\webform_strawberryfield;
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Form\FormStateInterface;
+
+class ElementHelper {
+
+    /**
+     * Form element validation handler for Core elements that require a string
+     * E.g Url, Email, Color.
+     *
+     * When passed a non string See \Drupal\Core\Render\Element\Url::validateUrl
+     * A 500 is returned. Our RAW JSON can contain empties as arrays.
+     *
+     */
+    public static function prevalidateForStringAndEmpty(&$element, FormStateInterface $form_state, &$complete_form) {
+        $is_empty_multiple = is_countable($element['#value']) && count($element['#value']) == 0;
+        $is_empty_string = (is_string($element['#value']) && mb_strlen(trim($element['#value'])) == 0);
+        $is_empty_value = ($element['#value'] === 0);
+        $is_empty_null = is_null($element['#value']);
+        if ($is_empty_multiple || $is_empty_string || $is_empty_value || $is_empty_null) {
+            $value = "";
+            $form_state->setValueForElement($element, $value);
+        }
+        elseif (!is_scalar($element['#value'])) {
+            $value = $element['#value'];
+            $form_state->setError($element, t('The passed value %url is not a string.', ['%url' => json_encode($value)]));
+            $element['#value'] =  json_encode($value);
+        }
+    }
+}

--- a/webform_strawberryfield.module
+++ b/webform_strawberryfield.module
@@ -735,5 +735,28 @@ function webform_strawberryfield_element_info_alter(array &$info): void {
   if (isset($info['webform_tus_file'])) {
     $info['webform_metadata_csv_file']['#value_callback'] = ['\Drupal\webform_strawberryfield\Element\WebformStrawberryFieldManagedFile', 'valueCallback'];
   }
+  // These element's have a "trim" in their validators, breaking with any other "empty" input
+  // In a bad way.
+  if (isset($info['url'])) {
+    $validate = $info['url']['#element_validate'] ?? [];
+    array_unshift(  $validate, ['\Drupal\webform_strawberryfield\ElementHelper', 'prevalidateForStringAndEmpty']);
+    $info['url']['#element_validate'] = array_values($validate);
+  }
+  if (isset($info['email'])) {
+    $validate = $info['email']['#element_validate'] ?? [];
+    array_unshift(  $validate, ['\Drupal\webform_strawberryfield\ElementHelper', 'prevalidateForStringAndEmpty']);
+    $info['email']['#element_validate'] = array_values($validate);
+  }
+  if (isset($info['color'])) {
+    $validate = $info['color']['#element_validate'] ?? [];
+    array_unshift(  $validate, ['\Drupal\webform_strawberryfield\ElementHelper', 'prevalidateForStringAndEmpty']);
+    $info['color']['#element_validate'] = array_values($validate);
+  }
+
+  if (isset($info['webform_email_multiple'])) {
+    $validate = $info['webform_email_multiple']['#element_validate'] ?? [];
+    array_unshift(  $validate, ['\Drupal\webform_strawberryfield\ElementHelper', 'prevalidateForStringAndEmpty']);
+    $info['webform_email_multiple']['#element_validate'] = array_values($validate);
+  }
 }
 


### PR DESCRIPTION
Generate a new prevalidateForStringAndEmpty for RAW JSON bringing FALSE/NULL/EMPTY arrays as initial values for core webform elements that do a "blind" trim on anything

See #210 