### PR TITLE
Do not pass a NULL body to json_decode() when a LoD Authority is unreachable

### DIFF
--- a/src/Controller/AuthAutocompleteController.php
+++ b/src/Controller/AuthAutocompleteController.php
@@ -322,11 +322,9 @@ class AuthAutocompleteController extends ControllerBase implements ContainerInje
     $options['headers'] = ['Accept' => 'application/json'];
     $body = $this->getRemoteJsonData($remoteUrl, $options);
 
-    $jsondata = [];
     $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       //LoC will always return at least one, the query string
       if (count($jsondata) > 1) {
         foreach ($jsondata[1] as $key => $label) {
@@ -344,14 +342,6 @@ class AuthAutocompleteController extends ControllerBase implements ContainerInje
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -370,11 +360,9 @@ class AuthAutocompleteController extends ControllerBase implements ContainerInje
     $options['headers'] = ['Accept' => 'application/json'];
     $body = $this->getRemoteJsonData($remoteUrl, $options);
 
-    $jsondata = [];
     $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       //WIKIdata will give is an success key will always return at least one, the query string
       if (count($jsondata) > 0) {
         if (($jsondata['success'] ?? 0) == 1) {
@@ -397,14 +385,6 @@ class AuthAutocompleteController extends ControllerBase implements ContainerInje
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -557,7 +537,11 @@ SPARQL;
         $url = Url::fromUri($baseurl, $options);
         $remoteUrl = $url->toString() . '&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql';
         $options['headers'] = ['Accept' => 'application/sparql-results+json'];
-        $bodies[] = $this->getRemoteJsonData($remoteUrl, $options);
+        // Keep the URL next to its body so a failing query can be named.
+        $bodies[] = [
+          'url' => $remoteUrl,
+          'body' => $this->getRemoteJsonData($remoteUrl, $options),
+        ];
       }
       // This is how a result here looks like
       /*
@@ -584,11 +568,9 @@ SPARQL;
     }
        */
 
-      $jsonfail = FALSE;
-      foreach($bodies as $body) {
-        $jsondata = json_decode($body, TRUE);
-        $json_error = json_last_error();
-        if ($json_error == JSON_ERROR_NONE) {
+      foreach($bodies as $fetched) {
+        $jsondata = $this->decodeRemoteJsonData($fetched['body'], $fetched['url']);
+        if ($jsondata !== NULL) {
           if (isset($jsondata['results']) && count($jsondata['results']['bindings']) > 0) {
             if (is_array($original_search)) {
               $original_search_string = implode(" ", $original_search);
@@ -622,9 +604,6 @@ SPARQL;
             }
           }
         }
-        else {
-          $jsonfail = TRUE;
-        }
       }
       if (empty($results)) {
         $results[] = [
@@ -632,16 +611,6 @@ SPARQL;
           'label' => 'Sorry no Match from Getty ' . $vocab . ' Vocabulary',
           'desc' => NULL,
         ];
-      }
-      if ($jsonfail) {
-        $this->messenger()->addError(
-          $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-            [
-              '@url' => $remoteUrl,
-              '@jsonerror' => $json_error,
-            ]
-          )
-        );
       }
     }
     return $results;
@@ -661,11 +630,9 @@ SPARQL;
     $options['headers'] = ['Accept' => 'application/json'];
     $body = $this->getRemoteJsonData($remoteUrl, $options);
 
-    $jsondata = [];
     $results = [];
-    $jsondata = json_decode($body, TRUE) ?? [];
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       if (count($jsondata) > 0) {
         if (isset($jsondata['result']) && is_array($jsondata['result']) && count($jsondata['result']) >= 1) {
           foreach ($jsondata['result'] as $key => $item) {
@@ -687,14 +654,6 @@ SPARQL;
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -741,9 +700,8 @@ SPARQL;
     $options['headers'] = ['Accept' => 'application/ld+json'];
     $body = $this->getRemoteJsonData($remoteUrl, $options);
     $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       /*
        {
       "@context": [
@@ -801,14 +759,6 @@ SPARQL;
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -958,11 +908,9 @@ SPARQL;
     ];
     $body = $this->getRemoteJsonData($remoteUrl, $options, 'PUT');
 
-    $jsondata = [];
     $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       if (!empty($jsondata['results']) &&  ($jsondata['total'] ?? 0) >= 1) {
         foreach ($jsondata['results'] as $key => $entry) {
           $nameEntry = reset($entry['nameEntries']);
@@ -980,14 +928,6 @@ SPARQL;
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -1052,9 +992,8 @@ SPARQL;
     $options['headers'] = ['Accept' => 'application/json'];
     $body = $this->getRemoteJsonData($remoteUrl, $options);
     $results = [];
-    $jsondata = json_decode($body, TRUE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
+    $jsondata = $this->decodeRemoteJsonData($body, $remoteUrl);
+    if ($jsondata !== NULL) {
       if (count($jsondata) > 0) {
         foreach ($jsondata as $entry) {
           if (strtolower(trim($entry['label'] ?? '')) == strtolower($input)) {
@@ -1079,14 +1018,6 @@ SPARQL;
       }
       return $results;
     }
-    $this->messenger()->addError(
-      $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
-        [
-          '@url' => $remoteUrl,
-          '@jsonerror' => $json_error,
-        ]
-      )
-    );
     return [];
   }
 
@@ -1171,6 +1102,52 @@ SPARQL;
   }
 
   /**
+   * Decodes a response body previously fetched by ::getRemoteJsonData().
+   *
+   * ::getRemoteJsonData() returns NULL when the remote endpoint could not be
+   * reached at all: an empty or invalid URL, a timeout, or a 4xx/5xx answer.
+   * Passing that NULL straight to json_decode() is deprecated since PHP 8.1
+   * and becomes a TypeError in PHP 9, so it is dealt with here once instead of
+   * at every call site. It also means a Vocabulary/Authority service that is
+   * simply down is no longer reported back to the user as malformed JSON.
+   *
+   * @param string|null $body
+   *   The raw body returned by ::getRemoteJsonData().
+   * @param string $remoteUrl
+   *   The URL $body was fetched from. Only used to build the error message.
+   *
+   * @return array|null
+   *   The decoded JSON as an array, or NULL when there was nothing to decode.
+   */
+  protected function decodeRemoteJsonData(?string $body, string $remoteUrl): ?array {
+    if ($body === NULL || trim($body) === '') {
+      $this->messenger()->addError(
+        $this->t('We could not fetch any data from @url. The remote service might be down or timing out. Please try again later.',
+          [
+            '@url' => $remoteUrl,
+          ]
+        )
+      );
+      return NULL;
+    }
+    $jsondata = json_decode($body, TRUE);
+    if (json_last_error() != JSON_ERROR_NONE) {
+      $this->messenger()->addError(
+        $this->t('Looks like data fetched from @url is not in JSON format.<br> JSON says: @jsonerror <br>Please check your URL!',
+          [
+            '@url' => $remoteUrl,
+            '@jsonerror' => json_last_error_msg(),
+          ]
+        )
+      );
+      return NULL;
+    }
+    // A remote can legitimately answer with a JSON scalar or with `null`, but
+    // every caller here expects something it can count() and iterate over.
+    return is_array($jsondata) ? $jsondata : [];
+  }
+
+  /**
    * @return bool
    */
   public function isNotAllowed(): bool {
@@ -1219,7 +1196,10 @@ SPARQL;
     //"scope":"/read-public","orcid":null} &*/ or null/empt it wrong.
 
     $response = $this->getRemoteJsonData($remoteOrCIDAuthUrl, $options, 'POST');
-    $orcd_id_token_response = json_decode($response, TRUE);
+    // ::getRemoteJsonData() answers NULL when ORCID could not be reached, and
+    // json_decode() does not take NULL anymore. An empty string decodes to the
+    // same JSON_ERROR_SYNTAX, so the failure is still reported right below.
+    $orcd_id_token_response = json_decode($response ?? '', TRUE);
 
     $json_error = json_last_error();
 

--- a/tests/src/Unit/Controller/AuthAutocompleteControllerTest.php
+++ b/tests/src/Unit/Controller/AuthAutocompleteControllerTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Drupal\Tests\webform_strawberryfield\Unit\Controller;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform_strawberryfield\Controller\AuthAutocompleteController;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests how the LoD autocomplete handlers behave when an Authority is down.
+ */
+#[Group('webform_strawberryfield')]
+#[CoversClass(AuthAutocompleteController::class)]
+class AuthAutocompleteControllerTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $logger_factory->method('get')
+      ->willReturn($this->createMock(LoggerChannelInterface::class));
+
+    // Getty builds its SPARQL endpoint with Url::fromUri().
+    $url_assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $url_assembler->method('assemble')
+      ->willReturnCallback(fn($uri) => $uri);
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('messenger', $this->createMock(MessengerInterface::class));
+    $container->set('logger.factory', $logger_factory);
+    $container->set('unrouted_url_assembler', $url_assembler);
+    $container->set('state', $this->createMock(StateInterface::class));
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Builds a controller whose HTTP client replies with the given responses.
+   *
+   * @param \GuzzleHttp\Psr7\Response ...$queue
+   *   What the remote Authority answers, in order.
+   *
+   * @return \Drupal\webform_strawberryfield\Controller\AuthAutocompleteController
+   *   The controller under test.
+   */
+  protected function controllerReplyingWith(Response ...$queue): AuthAutocompleteController {
+    return new AuthAutocompleteController(
+      new Client(['handler' => HandlerStack::create(new MockHandler($queue))]),
+      $this->createMock(TimeInterface::class),
+      $this->createMock(AccountInterface::class),
+      $this->createMock(CacheBackendInterface::class),
+      $this->createMock(ConfigFactoryInterface::class)
+    );
+  }
+
+  /**
+   * Invokes one of the controller's protected Authority handlers.
+   */
+  protected function invoke(AuthAutocompleteController $controller, string $method, array $args) {
+    return (new \ReflectionMethod($controller, $method))->invoke($controller, ...$args);
+  }
+
+  /**
+   * Runs a callable, returning every PHP deprecation the module's code raised.
+   *
+   * @return array
+   *   A [result, deprecations] pair.
+   */
+  protected function collectDeprecations(callable $callable): array {
+    $module_src = dirname(__DIR__, 4) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
+    $deprecations = [];
+    set_error_handler(
+      function ($errno, $errstr, $errfile) use (&$deprecations, $module_src) {
+        if ($errno === E_DEPRECATED && str_starts_with((string) $errfile, $module_src)) {
+          $deprecations[] = $errstr;
+        }
+        return TRUE;
+      },
+      E_ALL
+    );
+    try {
+      $result = $callable();
+    }
+    finally {
+      restore_error_handler();
+    }
+    return [$result, $deprecations];
+  }
+
+  /**
+   * The Authority handlers and the arguments they take.
+   *
+   * @return array
+   *   Test cases keyed by Authority name.
+   */
+  public static function authorityHandlerProvider(): array {
+    return [
+      'LoC' => ['loc', ['Doe, John', 'names', NULL]],
+      'Wikidata' => ['wikidata', ['Doe, John']],
+      'VIAF' => ['viaf', ['Doe, John']],
+      'Europeana' => ['europeana', ['Doe, John', 'agent', 'anapikey']],
+      'SNAC' => ['snac', ['Doe, John', 'person', NULL]],
+      'MeSH' => ['mesh', ['Anemia', 'descriptor', NULL]],
+      'Getty' => ['getty', ['Anemia', 'aat', 'fuzzy']],
+    ];
+  }
+
+  /**
+   * An Authority that times out must not raise a PHP deprecation.
+   *
+   * ::getRemoteJsonData() returns NULL when the remote endpoint answers with a
+   * 5xx (which is how id.loc.gov presents while it is timing out) and feeding
+   * that NULL to json_decode() is deprecated as of PHP 8.1.
+   */
+  #[DataProvider('authorityHandlerProvider')]
+  public function testHandlerDoesNotDeprecateWhenAuthorityIsDown(string $method, array $args): void {
+    // Two responses queued: Getty issues more than one request per lookup.
+    $controller = $this->controllerReplyingWith(
+      new Response(504, [], 'Gateway Timeout'),
+      new Response(504, [], 'Gateway Timeout')
+    );
+
+    [$results, $deprecations] = $this->collectDeprecations(
+      fn() => $this->invoke($controller, $method, $args)
+    );
+
+    $this->assertSame([], $deprecations, 'No PHP deprecation is raised when the Authority can not be reached.');
+    $this->assertIsArray($results, 'The handler still answers the autocomplete with an array.');
+  }
+
+  /**
+   * The same must hold when the Authority answers with an empty body.
+   */
+  #[DataProvider('authorityHandlerProvider')]
+  public function testHandlerDoesNotDeprecateOnEmptyBody(string $method, array $args): void {
+    $controller = $this->controllerReplyingWith(
+      new Response(200, [], ''),
+      new Response(200, [], '')
+    );
+
+    [$results, $deprecations] = $this->collectDeprecations(
+      fn() => $this->invoke($controller, $method, $args)
+    );
+
+    $this->assertSame([], $deprecations);
+    $this->assertIsArray($results);
+  }
+
+  /**
+   * A working LoC lookup keeps returning its suggestions untouched.
+   *
+   * This is the control: the fix must not move the success path.
+   */
+  public function testLocStillReturnsSuggestions(): void {
+    // The shape id.loc.gov/authorities/names/suggest/ answers with.
+    $payload = json_encode([
+      'Doe',
+      ['Doe, John', 'Doe, Jane'],
+      ['', ''],
+      ['https://id.loc.gov/authorities/names/n1', 'https://id.loc.gov/authorities/names/n2'],
+    ]);
+    $controller = $this->controllerReplyingWith(new Response(200, [], $payload));
+
+    [$results, $deprecations] = $this->collectDeprecations(
+      fn() => $this->invoke($controller, 'loc', ['Doe', 'names', NULL])
+    );
+
+    $this->assertSame([], $deprecations);
+    $this->assertSame([
+      [
+        'value' => 'https://id.loc.gov/authorities/names/n1',
+        'label' => 'Doe, John',
+      ],
+      [
+        'value' => 'https://id.loc.gov/authorities/names/n2',
+        'label' => 'Doe, Jane',
+      ],
+    ], $results);
+  }
+
+  /**
+   * An Authority answering with a JSON scalar must not break count().
+   *
+   * Several handlers count() what they decoded, and json_decode('null') or
+   * json_decode('"a string"') is not countable.
+   */
+  public function testJsonScalarDoesNotBreakTheHandler(): void {
+    $controller = $this->controllerReplyingWith(new Response(200, [], 'null'));
+
+    [$results, $deprecations] = $this->collectDeprecations(
+      fn() => $this->invoke($controller, 'loc', ['Doe', 'names', NULL])
+    );
+
+    $this->assertSame([], $deprecations);
+    $this->assertIsArray($results);
+  }
+
+  /**
+   * A malformed body is still reported to the user as malformed JSON.
+   */
+  public function testMalformedJsonIsStillReported(): void {
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())
+      ->method('addError')
+      ->with($this->callback(function ($message) {
+        return str_contains((string) $message, 'is not in JSON format');
+      }));
+    \Drupal::getContainer()->set('messenger', $messenger);
+
+    $controller = $this->controllerReplyingWith(new Response(200, [], '<html>not json</html>'));
+
+    $this->assertSame([], $this->invoke($controller, 'loc', ['Doe', 'names', NULL]));
+  }
+
+  /**
+   * An unreachable Authority is reported as such, not as malformed JSON.
+   */
+  public function testUnreachableAuthorityIsNotReportedAsMalformedJson(): void {
+    $messages = [];
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->method('addError')
+      ->willReturnCallback(function ($message) use (&$messages) {
+        $messages[] = (string) $message;
+      });
+    \Drupal::getContainer()->set('messenger', $messenger);
+
+    $controller = $this->controllerReplyingWith(new Response(504, [], 'Gateway Timeout'));
+    $this->invoke($controller, 'loc', ['Doe', 'names', NULL]);
+
+    $this->assertNotEmpty($messages, 'The user is told something went wrong.');
+    foreach ($messages as $message) {
+      $this->assertStringNotContainsString('is not in JSON format', $message);
+    }
+  }
+
+  /**
+   * The ORCID token request also survives an unreachable orcid.org.
+   */
+  public function testOrcidAuthDoesNotDeprecateWhenOrcidIsDown(): void {
+    $controller = $this->controllerReplyingWith(new Response(504, [], 'Gateway Timeout'));
+
+    [$token, $deprecations] = $this->collectDeprecations(
+      fn() => $controller->getOrcIDAuth('a-client-id', 'a-secret')
+    );
+
+    $this->assertSame([], $deprecations);
+    $this->assertFalse($token, 'No token is handed back when ORCID can not be reached.');
+  }
+
+}


### PR DESCRIPTION
This PR proposes keeping a NULL response body away from `json_decode()` in the LoD autocomplete handlers, so an Authority endpoint that is timing out no longer raises a PHP deprecation and no longer tells the user their URL is wrong. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/232. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #216.

## What is going on

`AuthAutocompleteController::getRemoteJsonData()` answers `NULL` on every one of its failure paths: an empty URL, a URL that fails `UrlHelper::isValid()`, a `ClientException`, a `ServerException`, an unsupported method, and the explicit 401/404/500 checks. Each handler then passes that `NULL` straight into `json_decode()`, which is deprecated as of PHP 8.1 and becomes a `TypeError` in PHP 9.

`loc()` on line 327 is the one in your report, but the same two lines are repeated across the whole controller, so `wikidata()`, `getty()`, `viaf()`, `europeana()`, `snac()`, `mesh()` and the ORCID token request in `getOrcIDAuth()` all do it too. `NominatimController` is already safe because its own `getRemoteJsonData()` returns `"[]"` rather than `NULL`, but that same trick is not portable to this controller: `orcid()` asks the very same helper for CSV and checks `is_string($body)`, so handing it `"[]"` would send `"[]"` into `str_getcsv()`.

There is a second, user-facing half to this. `json_decode(NULL)` leaves `json_last_error()` at `JSON_ERROR_SYNTAX`, so each handler falls through to its `Looks like data fetched from @url is not in JSON format ... Please check your URL!` branch. When id.loc.gov is timing out, the person filling in the webform is told to go check a URL that is perfectly fine — and `@jsonerror` renders as the bare integer `4`.

## Reproducing it on current `main`

The unit test added here drives the real handlers through a Guzzle `MockHandler`, so no network is involved. Running it against `main` with only the controller restored:

```
$ git checkout main -- src/Controller/AuthAutocompleteController.php
$ vendor/bin/phpunit modules/contrib/webform_strawberryfield/tests/src/Unit/Controller/AuthAutocompleteControllerTest.php

1) AuthAutocompleteControllerTest::testHandlerDoesNotDeprecateWhenAuthorityIsDown with data set "LoC"
No PHP deprecation is raised when the Authority can not be reached.
--- Expected
+++ Actual
-Array &0 []
+Array &0 [
+    0 => 'json_decode(): Passing null to parameter #1 ($json) of type string is deprecated',
+]

2) AuthAutocompleteControllerTest::testJsonScalarDoesNotBreakTheHandler
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given
   src/Controller/AuthAutocompleteController.php:331

3) AuthAutocompleteControllerTest::testUnreachableAuthorityIsNotReportedAsMalformedJson
Failed asserting that 'Looks like data fetched from https://id.loc.gov/authorities/names/suggest/?q=Doe
is not in JSON format.<br> JSON says: 4 <br>Please check your URL!' does not contain "is not in JSON format".

Tests: 19, Assertions: 31, Errors: 1, Failures: 7, Deprecations: 1.
```

The `count()` `TypeError` in there is a live one on its own: it is what an Authority answering a bare JSON scalar (`null`, a string, a number) already costs you today, since `loc()`, `wikidata()`, `viaf()` and `mesh()` all `count()` whatever came back.

## The change

Decoding now goes through one new `decodeRemoteJsonData(?string $body, string $remoteUrl): ?array` helper, placed next to `getRemoteJsonData()`. It keeps the `NULL` away from `json_decode()`, distinguishes "we could not reach the service" from "that was not JSON" in the message shown to the user, reports `json_last_error_msg()` instead of the raw integer, and always returns an array so `count()` cannot fatal on a JSON scalar. Handlers now read `$jsondata = $this->decodeRemoteJsonData($body, $remoteUrl); if ($jsondata !== NULL) { ... }`, which deletes the seven copies of the `json_last_error()` block — the controller ends up 20 lines shorter.

Two small things fell out of it. `getty()` collects several bodies in one go and previously reported a failure against whichever `$remoteUrl` the earlier loop had left behind, so each body now travels next to the URL it came from. And `getOrcIDAuth()` keeps its own logging and its `bool|string` return exactly as they are — it only guards the `NULL` — because a background token fetch should not be pushing messages at whoever happens to load the next page.

Nothing on the success paths moved, and no public signature changed.

## Verification

Everything was run before and after on the same tree, against Drupal 11 and PHP 8.5:

- the new tests are red on `main` — 8 of the 19 fail, as quoted above — and green with the fix: **19 tests, 39 assertions, OK**. They cover all seven Authority handlers against both an unreachable endpoint and an empty body, plus the ORCID token request;
- `testLocStillReturnsSuggestions()` is the control — it asserts the exact array a healthy `id.loc.gov` lookup returns, so the success path is pinned;
- `testMalformedJsonIsStillReported()` pins the existing behaviour: a body that really is not JSON still raises the original message;
- `phpcs --standard=Drupal` on `AuthAutocompleteController.php` reports an **identical tally before and after** (259 / 34), so no new coding-standard violation was introduced — the pre-existing ones are left alone rather than swept up in here;
- `phpcs --standard=Drupal` on the new test file is clean;
- `php -l` across every PHP file in the module: no syntax errors, unchanged.

The test lands in `tests/src/Unit/Controller/`, uses `#[Group]`/`#[DataProvider]` attributes, and needs nothing beyond `drupal/core-dev`.

## How this was managed

This work was picked up and tracked as [a single story](https://eastagiletracker.com/projects/232/stories/96039) on [a board](https://eastagiletracker.com/projects/232) imported from this repository's own issues, pull requests and milestones — 213 stories and 25 labels. The board is live and readable without an account.

![board](https://raw.githubusercontent.com/eastagiletracker/webform_strawberryfield/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
